### PR TITLE
FLUT-6977 - Revamp the code snippet in Flutter PDF UG documentation - Hotfix

### DIFF
--- a/Flutter/pdf/getting-started.md
+++ b/Flutter/pdf/getting-started.md
@@ -81,7 +81,7 @@ Future<void> _createPDF() async {
       bounds: Rect.fromLTWH(0, 0, 500, 50));
 
   //Save the document
-  List<int> bytes = document.save();
+  List<int> bytes = await document.save();
 
   //Dispose the document
   document.dispose();
@@ -119,7 +119,7 @@ Include the following code snippet in _createPDF method to open the PDF document
 {% highlight dart %}
 
 //Get external storage directory
-final directory = await getApplicationDocumentsDirectory();
+final directory = await getApplicationSupportDirectory();
 
 //Get directory path
 final path = directory.path;
@@ -194,10 +194,10 @@ PdfDocument document = PdfDocument();
 //Draw the image
 document.pages.add().graphics.drawImage(
     PdfBitmap(File('image.jpg').readAsBytesSync()),
-    Rect.fromLTWH(0, 0, 100, 100));
+   Rect.fromLTWH(0, 0, 100, 100));
 
 //Saves the document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 
 //Dispose the document
 document.dispose();
@@ -242,10 +242,10 @@ row.cells[2].value = '8';
 
 //Draw grid to the page of the PDF document
 grid.draw(
-    page: document.pages.add(), bounds: const Rect.fromLTWH(0, 0, 0, 0));
+    page: document.pages.add(), bounds: Rect.fromLTWH(0, 0, 0, 0));
 
 //Saves the document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 
 //Dispose the document
 document.dispose();
@@ -485,7 +485,7 @@ The following code example shows how to save the invoice document and dispose th
 {% highlight dart %}
 
 //Saves the document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 
 //Dispose the document
 document.dispose();

--- a/Flutter/pdf/working-with-annotations.md
+++ b/Flutter/pdf/working-with-annotations.md
@@ -56,7 +56,7 @@ PdfPage page = document.pages[0];
 
 //Creates a rectangle annotation
 PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
-    const Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
+    Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     modifiedDate: DateTime.now());
@@ -90,7 +90,7 @@ PdfPage page = document.pages.add();
 
 //Creates a rectangle annotation
 PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
-    const Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
+    Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     innerColor: PdfColor(0, 0, 255),
@@ -124,7 +124,7 @@ PdfPage page = document.pages.add();
 
 //Creates an ellipse annotation
 PdfEllipseAnnotation ellipseAnnotation = PdfEllipseAnnotation(
-    const Rect.fromLTWH(40, 70, 80, 80), 'Ellipse Annotation',
+    Rect.fromLTWH(40, 70, 80, 80), 'Ellipse Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     innerColor: PdfColor(0, 0, 255),
@@ -233,8 +233,8 @@ PdfPage page = document.pages.add();
 
 //Creates a new document link annotation
 PdfDocumentLinkAnnotation documentLinkAnnotation =
-    PdfDocumentLinkAnnotation(const Rect.fromLTWH(10, 40, 30, 30),
-        PdfDestination(document.pages.add(), const Offset(10, 0)));
+    PdfDocumentLinkAnnotation(Rect.fromLTWH(10, 40, 30, 30),
+        PdfDestination(document.pages.add(), Offset(10, 0)));
 
 //Adds this annotation the page.
 page.annotations.add(documentLinkAnnotation);
@@ -263,7 +263,7 @@ PdfPage page = document.pages.add();
 
 //Creates a new URI annotation
 PdfUriAnnotation uriAnnotation = PdfUriAnnotation(
-    bounds: const Rect.fromLTWH(10, 10, 100, 30), uri: 'http://www.google.com');
+    bounds: Rect.fromLTWH(10, 10, 100, 30), uri: 'http://www.google.com');
 
 //Adds this annotation to the page.
 page.annotations.add(uriAnnotation);
@@ -300,7 +300,7 @@ PdfTextWebLink textWebLink = PdfTextWebLink(
     pen: PdfPen(PdfColor(0, 0, 255)));
 
 //Draws the text web link to the page
-textWebLink.draw(page, const Offset(10, 10));
+textWebLink.draw(page, Offset(10, 10));
 
 //Saves the document
 File('output.pdf').writeAsBytes(await document.save());
@@ -400,7 +400,7 @@ PdfPage page = document.pages[0];
 PdfRectangleAnnotation annotation =
     page.annotations[0] as PdfRectangleAnnotation;
 annotation.border = PdfAnnotationBorder(4);
-annotation.bounds = const Rect.fromLTWH(300, 300, 100, 100);
+annotation.bounds = Rect.fromLTWH(300, 300, 100, 100);
 annotation.color = PdfColor(0, 0, 255);
 annotation.innerColor = PdfColor(0, 255, 0);
 annotation.text = 'Modified Annotation';

--- a/Flutter/pdf/working-with-annotations.md
+++ b/Flutter/pdf/working-with-annotations.md
@@ -36,7 +36,7 @@ PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
 page.annotations.add(rectangleAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -56,7 +56,7 @@ PdfPage page = document.pages[0];
 
 //Creates a rectangle annotation
 PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
-    Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
+    const Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     modifiedDate: DateTime.now());
@@ -65,7 +65,7 @@ PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
 page.annotations.add(rectangleAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -90,7 +90,7 @@ PdfPage page = document.pages.add();
 
 //Creates a rectangle annotation
 PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
-    Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
+    const Rect.fromLTWH(40, 70, 80, 80), 'Rectangle Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     innerColor: PdfColor(0, 0, 255),
@@ -101,7 +101,7 @@ PdfRectangleAnnotation rectangleAnnotation = PdfRectangleAnnotation(
 page.annotations.add(rectangleAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -124,7 +124,7 @@ PdfPage page = document.pages.add();
 
 //Creates an ellipse annotation
 PdfEllipseAnnotation ellipseAnnotation = PdfEllipseAnnotation(
-    Rect.fromLTWH(40, 70, 80, 80), 'Ellipse Annotation',
+    const Rect.fromLTWH(40, 70, 80, 80), 'Ellipse Annotation',
     author: 'Syncfusion',
     color: PdfColor(255, 0, 0),
     innerColor: PdfColor(0, 0, 255),
@@ -135,7 +135,7 @@ PdfEllipseAnnotation ellipseAnnotation = PdfEllipseAnnotation(
 page.annotations.add(ellipseAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -177,7 +177,7 @@ PdfLineAnnotation lineAnnotation = PdfLineAnnotation(
 page.annotations.add(lineAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -210,7 +210,7 @@ PdfPolygonAnnotation polygonAnnotation = PdfPolygonAnnotation(
 page.annotations.add(polygonAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -233,14 +233,14 @@ PdfPage page = document.pages.add();
 
 //Creates a new document link annotation
 PdfDocumentLinkAnnotation documentLinkAnnotation =
-    PdfDocumentLinkAnnotation(Rect.fromLTWH(10, 40, 30, 30),
-        PdfDestination(document.pages.add(), Offset(10, 0)));
+    PdfDocumentLinkAnnotation(const Rect.fromLTWH(10, 40, 30, 30),
+        PdfDestination(document.pages.add(), const Offset(10, 0)));
 
 //Adds this annotation the page.
 page.annotations.add(documentLinkAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -263,13 +263,13 @@ PdfPage page = document.pages.add();
 
 //Creates a new URI annotation
 PdfUriAnnotation uriAnnotation = PdfUriAnnotation(
-    bounds: Rect.fromLTWH(10, 10, 100, 30), uri: 'http://www.google.com');
+    bounds: const Rect.fromLTWH(10, 10, 100, 30), uri: 'http://www.google.com');
 
 //Adds this annotation to the page.
 page.annotations.add(uriAnnotation);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -300,10 +300,10 @@ PdfTextWebLink textWebLink = PdfTextWebLink(
     pen: PdfPen(PdfColor(0, 0, 255)));
 
 //Draws the text web link to the page
-textWebLink.draw(page, Offset(10, 10));
+textWebLink.draw(page, const Offset(10, 10));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -336,7 +336,7 @@ for (int i = 0; i < document.pages.count; i++) {
 }
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -376,7 +376,7 @@ for (int i = 0; i < document.pages.count; i++) {
 }
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -400,7 +400,7 @@ PdfPage page = document.pages[0];
 PdfRectangleAnnotation annotation =
     page.annotations[0] as PdfRectangleAnnotation;
 annotation.border = PdfAnnotationBorder(4);
-annotation.bounds = Rect.fromLTWH(300, 300, 100, 100);
+annotation.bounds = const Rect.fromLTWH(300, 300, 100, 100);
 annotation.color = PdfColor(0, 0, 255);
 annotation.innerColor = PdfColor(0, 255, 0);
 annotation.text = 'Modified Annotation';
@@ -408,7 +408,7 @@ annotation.author = 'Syncfusion';
 annotation.modifiedDate = DateTime.now();
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -435,7 +435,7 @@ PdfAnnotationCollection collection = page.annotations;
 collection.remove(collection[0]);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();

--- a/Flutter/pdf/working-with-attachments.md
+++ b/Flutter/pdf/working-with-attachments.md
@@ -28,7 +28,7 @@ document.attachments.add(PdfAttachment(
     description: 'Text File', mimeType: 'application/txt'));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -48,7 +48,7 @@ document.attachments.add(PdfAttachment.fromBase64String(
     description: 'Text File', mimeType: 'application/txt'));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -69,7 +69,7 @@ document.attachments.add(PdfAttachment(
     description: 'Text File', mimeType: 'application/txt'));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -96,7 +96,7 @@ document.attachments.remove(attachment);
 document.attachments.removeAt(1);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -124,7 +124,7 @@ for (int i = 0; i < attachmentCollection.count; i++) {
 }
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();

--- a/Flutter/pdf/working-with-bookmarks.md
+++ b/Flutter/pdf/working-with-bookmarks.md
@@ -24,7 +24,7 @@ PdfDocument document = PdfDocument();
 PdfBookmark bookmark = document.bookmarks.add('page 1');
 
 //Sets the destination page and destination location
-bookmark.destination = PdfDestination(document.pages.add(), const Offset(100, 100));
+bookmark.destination = PdfDestination(document.pages.add(), Offset(100, 100));
 
 //Sets the text style
 bookmark.textStyle = [PdfTextStyle.bold];
@@ -66,8 +66,8 @@ childBookmark1.textStyle = [PdfTextStyle.bold, PdfTextStyle.italic];
 childBookmark2.textStyle = [PdfTextStyle.italic];
 
 //Sets the destination page and destination location
-childBookmark1.destination = PdfDestination(page, const Offset(100, 100));
-childBookmark2.destination = PdfDestination(page, const Offset(100, 400));
+childBookmark1.destination = PdfDestination(page, Offset(100, 100));
+childBookmark2.destination = PdfDestination(page, Offset(100, 400));
 
 //Sets the bookmark color(RGB)
 childBookmark1.color = PdfColor(0, 255, 0);
@@ -95,7 +95,7 @@ PdfDocument document =
 PdfBookmark bookmark = document.bookmarks.add('Page 1');
 
 //Sets the destination page and location
-bookmark.destination = PdfDestination(document.pages[0], const Offset(20, 20));
+bookmark.destination = PdfDestination(document.pages[0], Offset(20, 20));
 
 //Sets the bookmark color
 bookmark.color = PdfColor(255, 0, 0);
@@ -127,7 +127,7 @@ PdfDocument document =
 PdfBookmark bookmark = document.bookmarks.insert(1, 'New Bookmark');
 
 //Sets the destination page and location
-bookmark.destination = PdfDestination(document.pages[0], const Offset(40, 40));
+bookmark.destination = PdfDestination(document.pages[0], Offset(40, 40));
 
 //Saves the document
 File('output.pdf').writeAsBytes(await document.save());
@@ -190,13 +190,13 @@ PdfBookmarkBase collection = document.bookmarks;
 //Gets the first bookmark and changes the properties of the bookmark
 PdfBookmark bookmark = collection[0];
 bookmark.color = PdfColor(0, 0, 255);
-bookmark.destination = PdfDestination(page, const Offset(20, 20));
+bookmark.destination = PdfDestination(page, Offset(20, 20));
 bookmark.textStyle = [PdfTextStyle.italic];
 bookmark.title = 'Changed Title';
 
 //Adds a child to the existing bookmark
 PdfBookmark childBookmark = bookmark.add('Child Bookmark');
-childBookmark.destination = PdfDestination(page, const Offset(100, 100));
+childBookmark.destination = PdfDestination(page, Offset(100, 100));
 
 //Saves the document
 File('output.pdf').writeAsBytes(await document.save());

--- a/Flutter/pdf/working-with-bookmarks.md
+++ b/Flutter/pdf/working-with-bookmarks.md
@@ -89,7 +89,7 @@ To add [`bookmarks`](https://pub.dev/documentation/syncfusion_flutter_pdf/latest
 
 //Loads an existing PDF document
 PdfDocument document =
-    PdfDocument(inputBytes: File('').readAsBytesSync());
+    PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Creates a document bookmark
 PdfBookmark bookmark = document.bookmarks.add('Page 1');

--- a/Flutter/pdf/working-with-bookmarks.md
+++ b/Flutter/pdf/working-with-bookmarks.md
@@ -24,7 +24,7 @@ PdfDocument document = PdfDocument();
 PdfBookmark bookmark = document.bookmarks.add('page 1');
 
 //Sets the destination page and destination location
-bookmark.destination = PdfDestination(document.pages.add(), Offset(100, 100));
+bookmark.destination = PdfDestination(document.pages.add(), const Offset(100, 100));
 
 //Sets the text style
 bookmark.textStyle = [PdfTextStyle.bold];
@@ -33,7 +33,7 @@ bookmark.textStyle = [PdfTextStyle.bold];
 bookmark.color = PdfColor(255, 0, 0);
 
 //Save the document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 
 //Dispose the document
 document.dispose();
@@ -66,15 +66,15 @@ childBookmark1.textStyle = [PdfTextStyle.bold, PdfTextStyle.italic];
 childBookmark2.textStyle = [PdfTextStyle.italic];
 
 //Sets the destination page and destination location
-childBookmark1.destination = PdfDestination(page, Offset(100, 100));
-childBookmark2.destination = PdfDestination(page, Offset(100, 400));
+childBookmark1.destination = PdfDestination(page, const Offset(100, 100));
+childBookmark2.destination = PdfDestination(page, const Offset(100, 400));
 
 //Sets the bookmark color(RGB)
 childBookmark1.color = PdfColor(0, 255, 0);
 childBookmark2.color = PdfColor(0, 0, 255);
 
 //Saves the bookmark
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 
 //Dispose the document
 document.dispose();
@@ -89,13 +89,13 @@ To add [`bookmarks`](https://pub.dev/documentation/syncfusion_flutter_pdf/latest
 
 //Loads an existing PDF document
 PdfDocument document =
-    PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
+    PdfDocument(inputBytes: File('').readAsBytesSync());
 
 //Creates a document bookmark
 PdfBookmark bookmark = document.bookmarks.add('Page 1');
 
 //Sets the destination page and location
-bookmark.destination = PdfDestination(document.pages[0], Offset(20, 20));
+bookmark.destination = PdfDestination(document.pages[0], const Offset(20, 20));
 
 //Sets the bookmark color
 bookmark.color = PdfColor(255, 0, 0);
@@ -104,7 +104,7 @@ bookmark.color = PdfColor(255, 0, 0);
 bookmark.textStyle = [PdfTextStyle.bold];
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
   
 //Disposes the document
 document.dispose();
@@ -127,10 +127,10 @@ PdfDocument document =
 PdfBookmark bookmark = document.bookmarks.insert(1, 'New Bookmark');
 
 //Sets the destination page and location
-bookmark.destination = PdfDestination(document.pages[0], Offset(40, 40));
+bookmark.destination = PdfDestination(document.pages[0], const Offset(40, 40));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -157,7 +157,7 @@ bookmark.removeAt(1);
 bookmark.remove('Page 1');
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -190,16 +190,16 @@ PdfBookmarkBase collection = document.bookmarks;
 //Gets the first bookmark and changes the properties of the bookmark
 PdfBookmark bookmark = collection[0];
 bookmark.color = PdfColor(0, 0, 255);
-bookmark.destination = PdfDestination(page, Offset(20, 20));
+bookmark.destination = PdfDestination(page, const Offset(20, 20));
 bookmark.textStyle = [PdfTextStyle.italic];
 bookmark.title = 'Changed Title';
 
 //Adds a child to the existing bookmark
 PdfBookmark childBookmark = bookmark.add('Child Bookmark');
-childBookmark.destination = PdfDestination(page, Offset(100, 100));
+childBookmark.destination = PdfDestination(page, const Offset(100, 100));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();

--- a/Flutter/pdf/working-with-digital-signature.md
+++ b/Flutter/pdf/working-with-digital-signature.md
@@ -98,11 +98,11 @@ field.signature = PdfSignature(
 PdfGraphics graphics = field.appearance.normal.graphics;
 
 //Draws the signature image.
-graphics.drawImage(
-    PdfBitmap(File('image.jpg').readAsBytesSync()), field.bounds);
+graphics!.drawImage(
+    PdfBitmap(File('image.jpg').readAsBytesSync()), Rect.fromLTWH(0, 0, field.bounds.width, field.bounds.height));
 
 //Save and dispose the PDF document.
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -131,7 +131,7 @@ field.signature = PdfSignature()
         [File('certificate.cer').readAsBytesSync()]);
 
 //Save and dispose the PDF document.
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-digital-signature.md
+++ b/Flutter/pdf/working-with-digital-signature.md
@@ -17,17 +17,17 @@ To add a digital signature, you need a certificate with private keys. The follow
 
 {% highlight dart %}
 
-//Creates a new PDF document.
+//Creates a new PDF document
 PdfDocument document = PdfDocument();
 
-//Adds a new page.
+//Adds a new page
 PdfPage page = document.pages.add();
 
-//Creates a digital signature and sets signature information.
+//Creates a digital signature and sets signature information
 PdfSignatureField field = PdfSignatureField(page, 'signature',
     bounds: Rect.fromLTWH(0, 0, 200, 100),
     signature: PdfSignature(
-        //Creates a certificate instance from the PFX file with a private key.
+        //Creates a certificate instance from the PFX file with a private key
         certificate:
             PdfCertificate(File('PDF.pfx').readAsBytesSync(), 'password123'),
         contactInfo: 'johndoe@owned.us',
@@ -36,11 +36,11 @@ PdfSignatureField field = PdfSignatureField(page, 'signature',
         digestAlgorithm: DigestAlgorithm.sha256,
         cryptographicStandard: CryptographicStandard.cms));
 
-//Add a signature field to the form.
+//Add a signature field to the form
 document.form.fields.add(field);
 
-//Save and dispose the PDF document.
-File('Output.pdf').writeAsBytes(document.save());
+//Save and dispose the PDF document
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -70,7 +70,7 @@ field.signature = PdfSignature(
     cryptographicStandard: CryptographicStandard.cades);
 
 //Save and dispose the PDF document.
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -207,7 +207,7 @@ field.signature = PdfSignature(
     cryptographicStandard: CryptographicStandard.cades);
 
 //Save and load the PDF document.
-document = PdfDocument(inputBytes: document.save());
+document = PdfDocument(inputBytes: await document.save());
 
 //Gets the second signature field of the PDF document.
 field = document.form.fields[1] as PdfSignatureField;
@@ -224,7 +224,7 @@ field.signature = PdfSignature(
     cryptographicStandard: CryptographicStandard.cms);
 
 //Save and dispose the PDF document.
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-forms.md
+++ b/Flutter/pdf/working-with-forms.md
@@ -814,7 +814,7 @@ final PdfDocument document =
 
 //Import the FDF into the existing form.
 document.form
-  ..importData(File('Import.fdf').readAsBytesSync(), DataFormat.fdf);
+  .importData(File('Import.fdf').readAsBytesSync(), DataFormat.fdf);
 
 //Save the PDF document.
 File('output.pdf').writeAsBytesSync(await document.save());
@@ -835,7 +835,7 @@ final PdfDocument document =
 
 //Import the XFDF into the existing form.
 document.form
-  ..importData(File('Import.xfdf').readAsBytesSync(), DataFormat.xfdf);
+  .importData(File('Import.xfdf').readAsBytesSync(), DataFormat.xfdf);
 
 //Save the PDF document.
 File('output.pdf').writeAsBytesSync(await document.save());
@@ -856,7 +856,7 @@ final PdfDocument document =
 
 //Import the JSON into the existing form.
 document.form
-  ..importData(File('Import.json').readAsBytesSync(), DataFormat.json);
+  .importData(File('Import.json').readAsBytesSync(), DataFormat.json);
 
 //Enable the form default appearance.
 document.form.setDefaultAppearance(true);
@@ -880,7 +880,7 @@ final PdfDocument document =
 
 //Import the XML into the existing form.
 document.form
-  ..importData(File('Import.xml').readAsBytesSync(), DataFormat.xml);
+  .importData(File('Import.xml').readAsBytesSync(), DataFormat.xml);
 
 //Save the PDF document.
 File('output.pdf').writeAsBytesSync(await document.save());
@@ -899,7 +899,7 @@ The following code sample explains how to export the FDF file from a PDF documen
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to FDF format.
-File('Export.fdf').writeAsBytesSync(await document.form.exportData(DataFormat.fdf));
+File('Export.fdf').writeAsBytesSync(document.form.exportData(DataFormat.fdf));
 
 //Dispose the PDF document.
 document.dispose();
@@ -918,7 +918,7 @@ The following code sample explains how to export the XFDF file from a PDF docume
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to XFDF format.
-File('Export.xfdf').writeAsBytesSync(await document.form.exportData(DataFormat.xfdf));
+File('Export.xfdf').writeAsBytesSync(document.form.exportData(DataFormat.xfdf));
 
 //Dispose the PDF document.
 document.dispose();
@@ -936,7 +936,7 @@ The following code sample explains how to export JSON files from a PDF document.
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to JSON format.
-File('Export.json').writeAsBytesSync(await document.form.exportData(DataFormat.json));
+File('Export.json').writeAsBytesSync(document.form.exportData(DataFormat.json));
 
 //Dispose the PDF document.
 document.dispose();
@@ -955,7 +955,7 @@ The following code sample explains how to export an XML file from a PDF document
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to XML format.
-File('Export.xml').writeAsBytesSync(await document.form.exportData(DataFormat.xml));
+File('Export.xml').writeAsBytesSync(document.form.exportData(DataFormat.xml));
 
 //Dispose the PDF document.
 document.dispose();

--- a/Flutter/pdf/working-with-forms.md
+++ b/Flutter/pdf/working-with-forms.md
@@ -38,7 +38,7 @@ document.form.fields.add(PdfTextBoxField(
     foreColor: PdfColor(0, 0, 255)));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -62,7 +62,7 @@ document.form.fields.add(PdfTextBoxField(
     foreColor: PdfColor(0, 0, 255)));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -91,7 +91,7 @@ document.form.fields.add(PdfComboBoxField(
     ]));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -117,7 +117,7 @@ document.form.fields.add(PdfComboBoxField(
     ]));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -158,7 +158,7 @@ selectedIndex: 0,
 ));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -196,7 +196,7 @@ selectedIndex: 0,
 ));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -220,7 +220,7 @@ if (radioButtonListField is PdfRadioButtonListField &&
 }
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -250,7 +250,7 @@ document.form.fields.add(PdfListBoxField(
 document.form.setDefaultAppearance(true);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -277,7 +277,7 @@ document.form.fields.add(PdfListBoxField(
 document.form.setDefaultAppearance(true);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -305,7 +305,7 @@ document.form.fields.add(PdfCheckBoxField(
     isChecked: true));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -330,7 +330,7 @@ document.form.fields.add(PdfCheckBoxField(
     isChecked: true));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -367,7 +367,7 @@ document.form.fields.add(PdfSignatureField(document.pages[0], 'Sign',
     bounds: Rect.fromLTWH(100, 100, 100, 50)));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -396,7 +396,7 @@ document.form.fields.add(PdfButtonField(
 ..addPrintAction());
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -422,7 +422,7 @@ document.form.fields.add(PdfButtonField(
 ..addPrintAction());
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -445,7 +445,7 @@ document.form.setDefaultAppearance(true);
 (document.form.fields[0] as PdfTextBoxField).text = 'Updated';
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -474,7 +474,7 @@ if (field is PdfTextBoxField) {
 }
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -503,7 +503,7 @@ if (field is PdfTextBoxField) {
   field.backColor = fColor;
 }
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -525,7 +525,7 @@ final PdfDocument document =
 (document.form.fields[0] as PdfTextBoxField).text = 'Updated';
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -546,7 +546,7 @@ if (comboBox is PdfComboBoxField && comboBox.selectedIndex != 1) {
 }
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -568,7 +568,7 @@ if (radioButtonListField is PdfRadioButtonListField &&
 }
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -586,7 +586,7 @@ final PdfDocument document =
 (document.form.fields[0] as PdfListBoxField).selectedIndexes = [1,3];
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -604,7 +604,7 @@ final PdfDocument document =
 (document.form.fields[0] as PdfCheckBoxField).isChecked = true;
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -629,7 +629,7 @@ for (int i = 0; i < document.form.fields.count; i++) {
 }
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -674,7 +674,7 @@ final PdfDocument document =
 document.form.flattenAllFields();
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -710,7 +710,7 @@ PdfDocument document =
     ..form.readOnly = true;
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -736,7 +736,7 @@ collection.removeAt(1);
 collection.remove(collection[0]);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -769,7 +769,7 @@ document.form.fields.add(PdfTextBoxField(
     text: 'Last name', spellCheck: true));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -796,7 +796,7 @@ document.form.fields.add(PdfButtonField(document.pages.add(),
     )));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -817,7 +817,7 @@ document.form
   ..importData(File('Import.fdf').readAsBytesSync(), DataFormat.fdf);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -838,7 +838,7 @@ document.form
   ..importData(File('Import.xfdf').readAsBytesSync(), DataFormat.xfdf);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -862,7 +862,7 @@ document.form
 document.form.setDefaultAppearance(true);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -883,7 +883,7 @@ document.form
   ..importData(File('Import.xml').readAsBytesSync(), DataFormat.xml);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}
 
@@ -899,7 +899,7 @@ The following code sample explains how to export the FDF file from a PDF documen
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to FDF format.
-File('Export.fdf').writeAsBytesSync(document.form.exportData(DataFormat.fdf));
+File('Export.fdf').writeAsBytesSync(await document.form.exportData(DataFormat.fdf));
 
 //Dispose the PDF document.
 document.dispose();
@@ -918,7 +918,7 @@ The following code sample explains how to export the XFDF file from a PDF docume
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to XFDF format.
-File('Export.xfdf').writeAsBytesSync(document.form.exportData(DataFormat.xfdf));
+File('Export.xfdf').writeAsBytesSync(await document.form.exportData(DataFormat.xfdf));
 
 //Dispose the PDF document.
 document.dispose();
@@ -936,7 +936,7 @@ The following code sample explains how to export JSON files from a PDF document.
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to JSON format.
-File('Export.json').writeAsBytesSync(document.form.exportData(DataFormat.json));
+File('Export.json').writeAsBytesSync(await document.form.exportData(DataFormat.json));
 
 //Dispose the PDF document.
 document.dispose();
@@ -955,7 +955,7 @@ The following code sample explains how to export an XML file from a PDF document
 PdfDocument document = PdfDocument(inputBytes: File('input.pdf').readAsBytesSync());
 
 //Export the form data to XML format.
-File('Export.xml').writeAsBytesSync(document.form.exportData(DataFormat.xml));
+File('Export.xml').writeAsBytesSync(await document.form.exportData(DataFormat.xml));
 
 //Dispose the PDF document.
 document.dispose();
@@ -990,6 +990,6 @@ document.form.fields.add(PdfListBoxField(
 document.form.setDefaultAppearance(true);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytesSync(document.save());
+File('output.pdf').writeAsBytesSync(await document.save());
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-layers.md
+++ b/Flutter/pdf/working-with-layers.md
@@ -33,13 +33,13 @@ PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(100, 60);
 
 //Draw an Arc.
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Add another layer on the page.
@@ -49,13 +49,13 @@ graphics = layer.graphics;
 graphics.translateTransform(100, 180);
 
 //Draw another set of elements.
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Save the PDF document.
@@ -81,13 +81,13 @@ PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(300, 360);
 
 //Draw an Arc.
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Save the PDF document.
@@ -113,14 +113,14 @@ PdfPage page = document.pages.add();
 PdfPageLayer layer = page.layers.add(name: 'Layer1', visible: true);
 PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(100, 60);
-graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
 
 //Add another layer on the page and disable the visibility.
 PdfPageLayer layer2 = page.layers.add(name: 'Layer2', visible: false);
 graphics = layer2.graphics;
 graphics.translateTransform(100, 180);
-graphics.drawEllipse(const Rect.fromLTWH(0, 0, 50, 50),
+graphics.drawEllipse(Rect.fromLTWH(0, 0, 50, 50),
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
 
 //Save the PDF document.
@@ -159,12 +159,12 @@ PdfPage page = document.pages.add();
 //Add the first layer.
 PdfLayer layer = document.layers.add(name: 'Layer1', visible: true)
   ..createGraphics(page).drawRectangle(
-      bounds: const Rect.fromLTWH(0, 0, 200, 100), brush: PdfBrushes.red);
+      bounds: Rect.fromLTWH(0, 0, 200, 100), brush: PdfBrushes.red);
 
 //Create nested layer.
 layer.layers.add(name: 'Nested Layer1', visible: true)
   ..createGraphics(page)
-      .drawRectangle(bounds: const Rect.fromLTWH(0, 120, 200, 100), brush: PdfBrushes.green);
+      .drawRectangle(bounds: Rect.fromLTWH(0, 120, 200, 100), brush: PdfBrushes.green);
 
 //Save the PDF document.
 File('output.pdf').writeAsBytes(await document.save());

--- a/Flutter/pdf/working-with-layers.md
+++ b/Flutter/pdf/working-with-layers.md
@@ -33,13 +33,13 @@ PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(100, 60);
 
 //Draw an Arc.
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Add another layer on the page.
@@ -49,17 +49,17 @@ graphics = layer.graphics;
 graphics.translateTransform(100, 180);
 
 //Draw another set of elements.
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 {% endhighlight %}
 
@@ -81,17 +81,17 @@ PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(300, 360);
 
 //Draw an Arc.
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 0, 250), width: 30));
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 250, 0), width: 20));
 graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(0, 250, 0), width: 10));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 {% endhighlight %}
 
@@ -113,18 +113,18 @@ PdfPage page = document.pages.add();
 PdfPageLayer layer = page.layers.add(name: 'Layer1', visible: true);
 PdfGraphics graphics = layer.graphics;
 graphics.translateTransform(100, 60);
-graphics.drawArc(Rect.fromLTWH(0, 0, 50, 50), 360, 360,
+graphics.drawArc(const Rect.fromLTWH(0, 0, 50, 50), 360, 360,
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
 
 //Add another layer on the page and disable the visibility.
 PdfPageLayer layer2 = page.layers.add(name: 'Layer2', visible: false);
 graphics = layer2.graphics;
 graphics.translateTransform(100, 180);
-graphics.drawEllipse(Rect.fromLTWH(0, 0, 50, 50),
+graphics.drawEllipse(const Rect.fromLTWH(0, 0, 50, 50),
     pen: PdfPen(PdfColor(250, 0, 0), width: 50));
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 {% endhighlight %}
 
@@ -140,7 +140,7 @@ PdfDocument document =
       ..pages[0].layers.removeAt(1);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 {% endhighlight %}
 
@@ -159,15 +159,15 @@ PdfPage page = document.pages.add();
 //Add the first layer.
 PdfLayer layer = document.layers.add(name: 'Layer1', visible: true)
   ..createGraphics(page).drawRectangle(
-      bounds: Rect.fromLTWH(0, 0, 200, 100), brush: PdfBrushes.red);
+      bounds: const Rect.fromLTWH(0, 0, 200, 100), brush: PdfBrushes.red);
 
 //Create nested layer.
 layer.layers.add(name: 'Nested Layer1', visible: true)
   ..createGraphics(page)
-      .drawRectangle(bounds: Rect.fromLTWH(0, 120, 200, 100), brush: PdfBrushes.green);
+      .drawRectangle(bounds: const Rect.fromLTWH(0, 120, 200, 100), brush: PdfBrushes.green);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 {% endhighlight %}
 
@@ -182,7 +182,7 @@ PdfDocument document =
     PdfDocument(inputBytes: File('input.pdf').readAsBytesSync())..layers.removeAt(0, false);
 
 //Save the PDF document.
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-pdf-conformance.md
+++ b/Flutter/pdf/working-with-pdf-conformance.md
@@ -27,10 +27,10 @@ You can create a PDF/A-1b document by specifying the conformance level as a1b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a1b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: Rect.fromLTWH(20, 20, 200, 50));
+      bounds: const Rect.fromLTWH(20, 20, 200, 50));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -47,10 +47,10 @@ You can create a PDF/A-2b document by specifying the conformance level as a2b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a2b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: Rect.fromLTWH(20, 20, 200, 50));
+      bounds: const Rect.fromLTWH(20, 20, 200, 50));
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();
@@ -69,7 +69,7 @@ You can create a PDF/A-3b document by specifying the conformance level as a3b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a3b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: Rect.fromLTWH(20, 20, 200, 50));
+      bounds: const Rect.fromLTWH(20, 20, 200, 50));
 
 //Creates an attachment
 PdfAttachment attachment = PdfAttachment(
@@ -82,7 +82,7 @@ PdfAttachment attachment = PdfAttachment(
 document.attachments.add(attachment);
 
 //Saves the document
-File('output.pdf').writeAsBytes(document.save());
+File('output.pdf').writeAsBytes(await document.save());
 
 //Disposes the document
 document.dispose();

--- a/Flutter/pdf/working-with-pdf-conformance.md
+++ b/Flutter/pdf/working-with-pdf-conformance.md
@@ -27,7 +27,7 @@ You can create a PDF/A-1b document by specifying the conformance level as a1b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a1b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: const Rect.fromLTWH(20, 20, 200, 50));
+      bounds: Rect.fromLTWH(20, 20, 200, 50));
 
 //Saves the document
 File('output.pdf').writeAsBytes(await document.save());
@@ -47,7 +47,7 @@ You can create a PDF/A-2b document by specifying the conformance level as a2b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a2b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: const Rect.fromLTWH(20, 20, 200, 50));
+      bounds: Rect.fromLTWH(20, 20, 200, 50));
 
 //Saves the document
 File('output.pdf').writeAsBytes(await document.save());
@@ -69,7 +69,7 @@ You can create a PDF/A-3b document by specifying the conformance level as a3b th
 PdfDocument document = PdfDocument(conformanceLevel: PdfConformanceLevel.a3b)
   ..pages.add().graphics.drawString('Hello World!',
       PdfTrueTypeFont(File('arial.ttf').readAsBytesSync(), 12),
-      bounds: const Rect.fromLTWH(20, 20, 200, 50));
+      bounds: Rect.fromLTWH(20, 20, 200, 50));
 
 //Creates an attachment
 PdfAttachment attachment = PdfAttachment(

--- a/Flutter/pdf/working-with-pdf-templates.md
+++ b/Flutter/pdf/working-with-pdf-templates.md
@@ -27,15 +27,15 @@ PdfTemplate template = PdfTemplate(100, 50);
 
 //Draw a rectangle on the template graphics
 template.graphics!.drawRectangle(
-    brush: PdfBrushes.burlyWood, bounds: const Rect.fromLTWH(0, 0, 100, 50));
+    brush: PdfBrushes.burlyWood, bounds: Rect.fromLTWH(0, 0, 100, 50));
 
 //Draw a string using the graphics of the template.
 template.graphics!.drawString(
     'Hello World', PdfStandardFont(PdfFontFamily.helvetica, 14),
-    brush: PdfBrushes.black, bounds: const Rect.fromLTWH(5, 5, 0, 0));
+    brush: PdfBrushes.black, bounds: Rect.fromLTWH(5, 5, 0, 0));
 
 //Add a new page and draw the template on the page graphics of the document.
-document.pages.add().graphics.drawPdfTemplate(template, const Offset(0, 0));
+document.pages.add().graphics.drawPdfTemplate(template, Offset(0, 0));
 
 //Save and dispose the PDF document
 File('Output.pdf').writeAsBytes(await document.save());
@@ -71,7 +71,7 @@ String imageData = base64.encode(imagebytes);
 //Draw the image in the header
 header.graphics.drawImage(
     PdfBitmap.fromBase64String(imageData),
-    const Rect.fromLTWH(0, 0, 100, 50));
+    Rect.fromLTWH(0, 0, 100, 50));
 
 //Add the header at the top
 document.template.top = header;
@@ -91,7 +91,7 @@ PdfCompositeField compositeField = PdfCompositeField(
 compositeField.bounds = footer.bounds;
 
 //Draw the composite field in footer
-compositeField.draw(footer.graphics, const Offset(470, 40));
+compositeField.draw(footer.graphics, Offset(470, 40));
 
 //Add the footer template at the bottom
 document.template.bottom = footer;

--- a/Flutter/pdf/working-with-pdf-templates.md
+++ b/Flutter/pdf/working-with-pdf-templates.md
@@ -27,18 +27,18 @@ PdfTemplate template = PdfTemplate(100, 50);
 
 //Draw a rectangle on the template graphics
 template.graphics!.drawRectangle(
-    brush: PdfBrushes.burlyWood, bounds: Rect.fromLTWH(0, 0, 100, 50));
+    brush: PdfBrushes.burlyWood, bounds: const Rect.fromLTWH(0, 0, 100, 50));
 
 //Draw a string using the graphics of the template.
 template.graphics!.drawString(
     'Hello World', PdfStandardFont(PdfFontFamily.helvetica, 14),
-    brush: PdfBrushes.black, bounds: Rect.fromLTWH(5, 5, 0, 0));
+    brush: PdfBrushes.black, bounds: const Rect.fromLTWH(5, 5, 0, 0));
 
 //Add a new page and draw the template on the page graphics of the document.
-document.pages.add().graphics.drawPdfTemplate(template, Offset(0, 0));
+document.pages.add().graphics.drawPdfTemplate(template, const Offset(0, 0));
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -63,10 +63,15 @@ PdfFont font = PdfStandardFont(PdfFontFamily.helvetica, 7);
 //Create a header and draw the image
 PdfPageTemplateElement header = PdfPageTemplateElement(bounds);
 
+//Get image data
+File imageFile = File('image.jpg');
+Uint8List imagebytes = await imageFile.readAsBytes();
+String imageData = base64.encode(imagebytes);
+
 //Draw the image in the header
 header.graphics.drawImage(
     PdfBitmap.fromBase64String(imageData),
-    Rect.fromLTWH(0, 0, 100, 50));
+    const Rect.fromLTWH(0, 0, 100, 50));
 
 //Add the header at the top
 document.template.top = header;
@@ -86,13 +91,13 @@ PdfCompositeField compositeField = PdfCompositeField(
 compositeField.bounds = footer.bounds;
 
 //Draw the composite field in footer
-compositeField.draw(footer.graphics, Offset(470, 40));
+compositeField.draw(footer.graphics, const Offset(470, 40));
 
 //Add the footer template at the bottom
 document.template.bottom = footer;
 
 //Save and dispose the PDF document
-File('SampleOutput.pdf').writeAsBytes(document.save());
+File('SampleOutput.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -134,7 +139,7 @@ page.graphics.drawRectangle(
     bounds: Offset(0, 0) & page.getClientSize());
 
 //Save the document
-final List<int> bytes = document.save();
+final List<int> bytes = await document.save();
 
 //Dispose the document
 document.dispose();

--- a/Flutter/pdf/working-with-security.md
+++ b/Flutter/pdf/working-with-security.md
@@ -38,7 +38,7 @@ security.userPassword = 'password';
 document.pages.add().graphics.drawString(
     'Encrypted with RC4 128bit', PdfStandardFont(PdfFontFamily.helvetica, 27),
     brush: PdfBrushes.mediumVioletRed,
-    bounds: const Rect.fromLTWH(10, 10, 500, 50));
+    bounds: Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
 File('Output.pdf').writeAsBytes(await document.save());
@@ -77,7 +77,7 @@ document.pages.add().graphics.drawString(
     'This document is protected with owner password',
     PdfStandardFont(PdfFontFamily.helvetica, 27),
     brush: PdfBrushes.mediumVioletRed,
-    bounds: const Rect.fromLTWH(10, 10, 500, 50));
+    bounds: Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
 File('Output.pdf').writeAsBytes(await document.save());
@@ -107,7 +107,7 @@ security.userPassword = 'password';
 document.pages.add().graphics.drawString(
     'Encrypted with AES 256bit', PdfStandardFont(PdfFontFamily.helvetica, 27),
     brush: PdfBrushes.mediumVioletRed,
-    bounds: const Rect.fromLTWH(10, 10, 500, 50));
+    bounds: Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
 File('Output.pdf').writeAsBytes(await document.save());
@@ -141,7 +141,7 @@ document.pages.add().graphics.drawString(
     'This document is protected with owner password',
     PdfStandardFont(PdfFontFamily.helvetica, 27),
     brush: PdfBrushes.mediumVioletRed,
-    bounds: const Rect.fromLTWH(10, 10, 500, 50));
+    bounds: Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
 File('Output.pdf').writeAsBytes(await document.save());

--- a/Flutter/pdf/working-with-security.md
+++ b/Flutter/pdf/working-with-security.md
@@ -41,7 +41,7 @@ document.pages.add().graphics.drawString(
     bounds: const Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -80,7 +80,7 @@ document.pages.add().graphics.drawString(
     bounds: const Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -110,7 +110,7 @@ document.pages.add().graphics.drawString(
     bounds: const Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -119,7 +119,7 @@ You can protect the PDF document from printing, editing, copying with the [`owne
 
 {% highlight dart %}
 
-//Create a new PDF documentation
+//Create a new PDF document
 PdfDocument document = PdfDocument();
 
 //Document security
@@ -144,7 +144,7 @@ document.pages.add().graphics.drawString(
     bounds: const Rect.fromLTWH(10, 10, 500, 50));
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -170,7 +170,7 @@ security.ownerPassword = 'ownerPassword';
 security.userPassword = 'userPassword';
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -189,7 +189,7 @@ PdfDocument document = PdfDocument(
 document.security.userPassword = 'NewPassword';
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -208,7 +208,7 @@ PdfDocument document = PdfDocument(
 document.security.userPassword = '';
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -236,7 +236,7 @@ document.security.permissions.addAll(<PdfPermissionsFlags>[
     PdfPermissionsFlags.fullQualityPrint]);
 
 //Save and dispose the PDF document
-File('Output.pdf').writeAsBytes(document.save());
+File('Output.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-watermarks.md
+++ b/Flutter/pdf/working-with-watermarks.md
@@ -28,20 +28,23 @@ PdfGraphics graphics = document.pages.add().graphics;
 //Watermark text
 PdfGraphicsState state = graphics.save();
 
+//Set transparency and rotation 
 graphics.setTransparency(0.25);
 
 graphics.rotateTransform(-40);
 
+//Add text watermark 
 graphics.drawString('Imported using Essential PDF',
     PdfStandardFont(PdfFontFamily.helvetica, 20),
     pen: PdfPens.red,
     brush: PdfBrushes.red,
-    bounds: Rect.fromLTWH(-150, 450, 0, 0));
+    bounds: const Rect.fromLTWH(-150, 450, 0, 0));
 
+//Restore graphics state
 graphics.restore(state);
 
 //Save and dispose the PDF document
-File('SampleOutput.pdf').writeAsBytes(document.save());
+File('SampleOutput.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}
@@ -60,17 +63,22 @@ PdfDocument document = PdfDocument();
 //Add a page to the document and get page graphics
 PdfGraphics graphics = document.pages.add().graphics;
 
+//Get image data
+File imageFile = File('image.jpg'); 
+Uint8List imagebytes = await imageFile.readAsBytes();
+String imageBase64 = base64.encode(imagebytes);
+
 //Watermark image
 PdfGraphicsState state = graphics.save();
 graphics.setTransparency(0.25);
 graphics.drawImage(
-    PdfBitmap.fromBase64String(imageData),
+    PdfBitmap.fromBase64String(imageBase64),
     Rect.fromLTWH(
         0, 0, graphics.clientSize.width, graphics.clientSize.height));
 graphics.restore(state);
 
 //Save and dispose the PDF document
-File('SampleOutput.pdf').writeAsBytes(document.save());
+File('SampleOutput.pdf').writeAsBytes(await document.save());
 document.dispose();
 
 {% endhighlight %}

--- a/Flutter/pdf/working-with-watermarks.md
+++ b/Flutter/pdf/working-with-watermarks.md
@@ -38,7 +38,7 @@ graphics.drawString('Imported using Essential PDF',
     PdfStandardFont(PdfFontFamily.helvetica, 20),
     pen: PdfPens.red,
     brush: PdfBrushes.red,
-    bounds: const Rect.fromLTWH(-150, 450, 0, 0));
+    bounds: Rect.fromLTWH(-150, 450, 0, 0));
 
 //Restore graphics state
 graphics.restore(state);


### PR DESCRIPTION
Hi All, 

I have revamp the code snippet in Flutter PDF UG documentation and please find the changes from below, 

- Added the **await** keyword before saving the PDF document. 

**Topics:** 
- Bookmarks 
- Watermarks 
- PDF Template 
- Annotation 
- Security 
- Digital Signature 
- Text extraction 
- PDF Conformance 
- Attachments 
- Layers 
- Getting Started 
- Modified the method name "getApplicationSupportDirectory" instead of "getApplicationDocumentsDirectory".

Kindly review the changes and let me know your feedback for the same. 

Regards,
Sowmiya L