### PR TITLE
FLUT-7032 - [Bug] Resolved issues in charts ug

### DIFF
--- a/Flutter/cartesian-charts/callbacks.md
+++ b/Flutter/cartesian-charts/callbacks.md
@@ -684,14 +684,14 @@ The [`onRenderDetailsUpdate`](https://pub.dev/documentation/syncfusion_flutter_c
 
 ## onRenderDetailsUpdate (Trendline)
 
-Triggers when the trendline gets rendered. The `onRenderDetailsUpdate` callback contains the following arguments.
+Triggers when the trendline gets rendered. The [`onRenderDetailsUpdate`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/Trendline/onRenderDetailsUpdate.html) callback contains the following arguments.
 
-* `seriesName` - specifies the series name of the trendline.
-* `calculatedDataPoints` - specifies the calculated data points of the trendline.
-* `trendlineName` - specifies the name of the trendline.
-* `intercept` - specifies the intercept value of the trendline.
-* `rSquaredValue` - specifies the r-squared value of the trendline.
-* `slope` - specifies the slope value of the trendline.
+* [`seriesName`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrendlineRenderParams/seriesName.html) - specifies the series name of the trendline.
+* [`calculatedDataPoints`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrendlineRenderParams/calculatedDataPoints.html) - specifies the calculated data points of the trendline.
+* [`trendlineName`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrendlineRenderParams/trendlineName.html) - specifies the name of the trendline.
+* [`intercept`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/Trendline/intercept.html) - specifies the intercept value of the trendline.
+* [`rSquaredValue`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrendlineRenderParams/rSquaredValue.html) - specifies the r-squared value of the trendline.
+* [`slope`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrendlineRenderParams/slope.html) - specifies the slope value of the trendline.
 
 {% tabs %}
 {% highlight dart %}
@@ -993,11 +993,11 @@ Triggers while swiping on the plot area. Whenever the swiping happens on th
 
 ## onRenderDetailsUpdate (ErrorBarSeries)
 
-Triggers when the error bar is being rendered. In this `onRenderDetailsUpdate` callback, you can get the following arguments.
+Triggers when the error bar is being rendered. In this [`onRenderDetailsUpdate`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarSeries/onRenderDetailsUpdate.html) callback, you can get the following arguments.
 
-* `pointIndex` - To obtain the point index of the error bar.
-* `viewPortPointIndex` - To obtain the viewport index value of the error bar.
-* `calculatedErrorBarValues` - This contains the calculated error bar values such as `horizontalPositiveErrorValue`,`horizontalNegativeErrorValue`,`verticalPositiveErrorValue` and `verticalNegativeErrorValue`.
+* [`pointIndex`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarRenderDetails/pointIndex.html) - To obtain the point index of the error bar.
+* [`viewPortPointIndex`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarRenderDetails/viewPortPointIndex.html) - To obtain the viewport index value of the error bar.
+* [`calculatedErrorBarValues`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarRenderDetails/calculatedErrorBarValues.html)- This contains the calculated error bar values such as [`horizontalPositiveErrorValue`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarSeries/horizontalPositiveErrorValue.html),[`horizontalNegativeErrorValue`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarSeries/horizontalNegativeErrorValue.html),[`verticalPositiveErrorValue`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarSeries/verticalPositiveErrorValue.html) and [`verticalNegativeErrorValue`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ErrorBarSeries/verticalNegativeErrorValue.html).
 
 {% tabs %}
 {% highlight dart %}
@@ -1312,6 +1312,7 @@ Triggers while rendering the multi-level labels. Text and text styles such as co
 * [Customize the data labels using its callback event](https://www.syncfusion.com/kb/11679/how-to-customize-data-labels-using-callback-events-sfcartesianchart).
 
 * [Disabling trackball tooltip for particular series using its callback event](https://www.syncfusion.com/kb/11638/how-to-disable-trackball-tooltip-for-particular-series-in-cartesian-charts-sfcartesianchart).
+
 * [To Synchronize panning in multiple charts](https://www.syncfusion.com/kb/11533/how-to-synchronize-panning-in-multiple-charts-sfcartesianchart).
 
 >**Note**: `chartData` in the above code snippets is a class type list and holds the data for binding to the chart series. Refer [Bind data source](https://help.syncfusion.com/flutter/cartesian-charts/getting-started#bind-data-source) topic for more details.

--- a/Flutter/cartesian-charts/chart-types/stacked-bar-100-chart.md
+++ b/Flutter/cartesian-charts/chart-types/stacked-bar-100-chart.md
@@ -115,4 +115,4 @@ The [`width`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/cha
 * [Animation](/flutter/cartesian-charts/series-customization#animation)
 * [Gradient](/flutter/cartesian-charts/series-customization#gradient-fill)
 * [Empty points](/flutter/cartesian-charts/series-customization#empty-points)
-* [Sorting](/flutter/cartesian-charts/series-customization##sorting)
+* [Sorting](/flutter/cartesian-charts/series-customization#sorting)

--- a/Flutter/cartesian-charts/chart-types/stacked-column-chart.md
+++ b/Flutter/cartesian-charts/chart-types/stacked-column-chart.md
@@ -220,7 +220,6 @@ You can show the cumulative data label values using the [`showCumulativeValues`]
 #### See Also
 
 * [Cumulative and non-cumulative values on the stacked column charts](https://www.syncfusion.com/kb/13029/how-to-show-cumulative-and-non-cumulative-values-on-the-stacked-column-charts).
-
 * [Color palette](/flutter/cartesian-charts/series-customization#color-palette) 
 * [Color mapping](/flutter/cartesian-charts/series-customization#color-mapping-for-data-points)
 * [Animation](/flutter/cartesian-charts/series-customization#animation)

--- a/Flutter/cartesian-charts/export-cartesian-chart.md
+++ b/Flutter/cartesian-charts/export-cartesian-chart.md
@@ -21,7 +21,14 @@ To export the Cartesian chart as a PNG image, we can get the image by calling [`
     import 'dart:typed_data';
     import 'dart:ui' as ui;
     import 'package:flutter/material.dart';
+    import '../save_file_mobile.dart';
+    if (dart.library.html) '../save_file_web.dart';
+    import 'dart:async';
+
+    /// Chart import
     import 'package:syncfusion_flutter_charts/charts.dart';
+    /// Pdf import
+    import 'package:syncfusion_flutter_pdf/pdf.dart';
   
     class ExportChart extends StatefulWidget {
     
@@ -119,8 +126,8 @@ It is necessary to include the platform-specific file generating codes to save t
     import 'dart:typed_data';
     import 'dart:ui' as ui;
     import 'package:flutter/material.dart';
-    import '../save_file_mobile.dart'
-      if (dart.library.html) '../save_file_web.dart';
+    import '../save_file_mobile.dart';
+    if (dart.library.html) '../save_file_web.dart';
     import 'dart:async';
 
     /// Chart import.

--- a/Flutter/cartesian-charts/export-cartesian-chart.md
+++ b/Flutter/cartesian-charts/export-cartesian-chart.md
@@ -21,15 +21,8 @@ To export the Cartesian chart as a PNG image, we can get the image by calling [`
     import 'dart:typed_data';
     import 'dart:ui' as ui;
     import 'package:flutter/material.dart';
-    import '../save_file_mobile.dart';
-    if (dart.library.html) '../save_file_web.dart';
-    import 'dart:async';
-
-    /// Chart import
     import 'package:syncfusion_flutter_charts/charts.dart';
-    /// Pdf import
-    import 'package:syncfusion_flutter_pdf/pdf.dart';
-  
+     
     class ExportChart extends StatefulWidget {
     
       const ExportChart({Key? key}) : super(key: key);

--- a/Flutter/cartesian-charts/methods.md
+++ b/Flutter/cartesian-charts/methods.md
@@ -335,7 +335,7 @@ The [`show`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/char
 
 The [`showByIndex`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrackballBehavior/showByIndex.html) method is used to activate the trackball at the specified point index.
 
-[`pointIndex`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrackballDetails/pointIndex.html) - index of the point for which the trackball must be shown.
+[`pointIndex`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/TrackballDetails/pointIndex.html) index of the point for which the trackball must be shown.
 
 {% tabs %}
 {% highlight dart %} 

--- a/Flutter/cartesian-charts/selection.md
+++ b/Flutter/cartesian-charts/selection.md
@@ -351,7 +351,7 @@ Defaults to `true`.
 
 ![Toggle selection](images/selection/cartesian_deselection.gif)
 
-Also refer [selection event](./events#onselectionchanged) for customizing the selection further.
+Also refer [selection event](https://help.syncfusion.com/flutter/circular-charts/callbacks#onselectionchanged) for customizing the selection further.
 
 #### See Also
 

--- a/Flutter/cartesian-charts/zoom-pan.md
+++ b/Flutter/cartesian-charts/zoom-pan.md
@@ -345,7 +345,7 @@ Also refer [`zooming`](./callbacks#onzooming), [`zoom start`](./callbacks#onzoom
 
 ### Calculate range based on visible points
 
-The [`anchorRangeToVisiblePoints`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ChartAxis/anchorRangeToVisiblePoints.html)  property can be used to calculate the value axis range based on the visible points. When the property is set to false the value axis range will be calculated based on all the data points in the chart irrespective of visible points. For further reference, check this [AutoRangeCalculation](./axis-customization.md) section.
+The [`anchorRangeToVisiblePoints`](https://pub.dev/documentation/syncfusion_flutter_charts/latest/charts/ChartAxis/anchorRangeToVisiblePoints.html)  property can be used to calculate the value axis range based on the visible points. When the property is set to false the value axis range will be calculated based on all the data points in the chart irrespective of visible points. For further reference, check this [AutoRangeCalculation](https://help.syncfusion.com/flutter/cartesian-charts/axis-customization#auto-range-calculation) section.
 
 #### See Also
 

--- a/Flutter/circular-charts/selection.md
+++ b/Flutter/circular-charts/selection.md
@@ -170,7 +170,7 @@ Defaults to `true`.
 
 ![Toggle selection](images/selection/deselection.gif)
 
-Also refer [`selection event`](./events#onselectionchanged) for customizing the selection further.
+Also refer [`selection event`](https://help.syncfusion.com/flutter/circular-charts/callbacks#onselectionchanged) for customizing the selection further.
 
 #### See Also
 


### PR DESCRIPTION
### Bug Description ###

In Chart ug, some of the API was not given hyperlink and changed the alignment for package.

### Root Cause ###

In ug link, when used hyperlink its not worked

### Reason for not identifying earlier ###

Did not tested the ug document.

**Guidelines/documents are not followed**

Common guidelines / Core team guideline
Specification document
Requirement document

**Guidelines/documents are not given**

Common guidelines / Core team guideline
Specification document
Requirement document

**Reason:**
Requirement document

**Action taken:**
Fixed the issues in chart ug

**Related areas:**
No
               
### Is Breaking issue? ###

No

### Solution description ###

Added the hyperlink using Design document in flutter.

### Output screenshots ###

Post the output screenshots if an UI is affected or added due to this bug.

**Before changes:**

![image](https://user-images.githubusercontent.com/105289202/196677268-917a33d5-c47f-4fb3-bea9-fba6ebef891b.png)


**After changes:**
![image](https://user-images.githubusercontent.com/105289202/196677485-c29bf30a-cec8-4ffd-9aa9-bc2fff83bf4a.png)


### Areas affected and ensured ###

No, it not affect any areas.

### Does it have any known issues?

No

### Does it have memory leak?

No

### MR CheckList ###

- [x] Does it follow the design [guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/)? It is mandatory that, we should not move the changes without reading this.
- [ ] Did UI automation passed without errors? If it is customer issue, make sure it is included in the IR automation.
- [ ] Properly working in Xamarin.Forms [previewer](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/xaml/xaml-previewer?tabs=vswin).
- [ ] Ensured in iOS, Android, UWP and macOS (if supported).
- [ ] Have you ensured the changes in Android API 19 and iOS 9?
- [ ] Did you record this case in the unit test or UI test?