### PR TITLE
FLUT-921064 - [PDF Viewer] Correction in custom text selection context menu code sample.

### DIFF
--- a/Flutter/pdf-viewer/text-selection.md
+++ b/Flutter/pdf-viewer/text-selection.md
@@ -227,6 +227,7 @@ class _HomePageState extends State<HomePage> {
             _showContextMenu(context, details);
           }
         },
+        key: _pdfViewerKey,
         controller: _pdfViewerController,
         canShowTextSelectionMenu: false,
       ),


### PR DESCRIPTION
## Description ##

- Annotations not applied for the selected text lines in the PDF from the custom text selection context menu.
- Included the pdfViewer key which was missed in the sfpdfviewer widget to resolve this error. 