### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for barcode widget

### DIFF
--- a/Flutter/barcode/getting-started.md
+++ b/Flutter/barcode/getting-started.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Getting started with Flutter Barcodes (SfBarcodeGenerator)
 
-This section explains the steps required to add the barcode and set its symbology. This section covers only basic features needed to get started with Syncfusion barcode generator widget. 
+This section explains the steps required to add the barcode and set its symbology. This section covers only basic features needed to get started with Syncfusion<sup>&reg;</sup> barcode generator widget. 
 
 
 ## Add Flutter Barcode to an application
@@ -18,7 +18,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter Barcode dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter Barcode dependency to your pubspec.yaml file.
 
 {% highlight dart %} 
 
@@ -28,7 +28,7 @@ Add the Syncfusion Flutter Barcode dependency to your pubspec.yaml file.
 
 {% endhighlight %}
 
-N> Here **xx.x.xx** denotes the current version of [`Syncfusion Flutter Barcodes`](https://pub.dev/packages/syncfusion_flutter_barcodes/versions) package.
+N> Here **xx.x.xx** denotes the current version of [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes/versions) package.
 
 **Get packages**
 

--- a/Flutter/barcode/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/barcode/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfBarcodeGenerator
 documentation: ug
 ---
 
-# How to add Syncfusion Barcodes widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Barcodes widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Barcodes widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_barcodes/example) tab in [Syncfusion Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_barcodes/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Barcodes](https://pub.dev/packages/syncfusion_flutter_barcodes) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/barcode/one-dimensional.md
+++ b/Flutter/barcode/one-dimensional.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # One-dimensional symbology in Flutter Barcodes (SfBarcodeGenerator)
 
-The one-dimensional barcode represents the data by varying the widths and spacings of the parallel lines. These barcode types are also known as linear barcode types. The Syncfusion flutter barcode generator supports the following one-dimensional barcode types:
+The one-dimensional barcode represents the data by varying the widths and spacings of the parallel lines. These barcode types are also known as linear barcode types. The Syncfusion<sup>&reg;</sup> flutter barcode generator supports the following one-dimensional barcode types:
 
 * [`Codabar`](https://pub.dev/documentation/syncfusion_flutter_barcodes/latest/barcodes/Codabar-class.html)
 * [`Code39`](https://pub.dev/documentation/syncfusion_flutter_barcodes/latest/barcodes/Code39-class.html)

--- a/Flutter/barcode/overview.md
+++ b/Flutter/barcode/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Barcodes (SfBarcodeGenerator) Overview
 
-The Syncfusion Flutter Barcode Generator is a data visualization widget used to generate and display data in a machine-readable format. It provides a perfect approach to encode text using supported symbology types.
+The Syncfusion<sup>&reg;</sup> Flutter Barcode Generator is a data visualization widget used to generate and display data in a machine-readable format. It provides a perfect approach to encode text using supported symbology types.
 
 ![Overview flutter barcode](images/getting-started/overview1.jpg)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to(Barcode)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/34ba988c-e6b7-46e8-a586-d62749642da1)|![image](https://github.com/user-attachments/assets/ee47fa63-20c9-4f08-be63-7915fe1d33ae)|
|![image](https://github.com/user-attachments/assets/2be6eaa5-f237-45c3-8699-03911a0692d9)|![image](https://github.com/user-attachments/assets/fec6a275-554a-4b8e-938b-ac96d1ba39fe)|
|![image](https://github.com/user-attachments/assets/c835c150-baf9-4ce9-b7ab-2e914b5fa914)|![image](https://github.com/user-attachments/assets/ba12287b-6a02-441b-bffd-db92b82bb900)|
|![image](https://github.com/user-attachments/assets/f1acf1fc-aacc-4e30-84af-59047d6479a7)|![image](https://github.com/user-attachments/assets/ad65c106-3a24-4e6a-baa9-0f188cf8f466)|

**getting-started(Barcode)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/d2984dff-20d8-48e9-a2ab-0f5b9ac0628e)|![image](https://github.com/user-attachments/assets/acfe42b7-b840-4f12-a836-02b567c8b869)|

**one-dimensional(Barcode)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/09b212b6-573a-4448-9683-99b2df6e2b6a)|![image](https://github.com/user-attachments/assets/ebe8864e-7e58-44ec-99d1-59c6a92fcca7)|

**overview(Barcode)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/e9e7c977-b414-47d9-88a3-e66b41d33a35)|![image](https://github.com/user-attachments/assets/76d35c80-dc34-4032-9c40-0718229a9243)|