### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for calendar widget

### DIFF
--- a/Flutter/calendar/getting-started.md
+++ b/Flutter/calendar/getting-started.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 # Getting started with Flutter Event Calendar (SfCalendar)
-This section explains the steps required to add the calendar widget and populate appointments to the calendar widget. This section covers only basic features needed to get started with Syncfusion calendar widget.
+This section explains the steps required to add the calendar widget and populate appointments to the calendar widget. This section covers only basic features needed to get started with Syncfusion<sup>&reg;</sup> calendar widget.
 
 To get start quickly with our [Flutter event calendar widget](https://www.syncfusion.com/flutter-widgets/flutter-calendar), you can check on this video.
 
@@ -22,7 +22,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter calendar dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter calendar dependency to your pubspec.yaml file.
 
 {% highlight dart %}
 
@@ -32,7 +32,7 @@ syncfusion_flutter_calendar: ^xx.x.xx
 
 {% endhighlight %}
 
-N> Here **xx.x.xx** denotes the current version of [`Syncfusion Flutter Calendar`](https://pub.dev/packages/syncfusion_flutter_calendar/versions) package.
+N> Here **xx.x.xx** denotes the current version of [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar/versions) package.
 
 **Get packages** 
 

--- a/Flutter/calendar/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/calendar/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfCalendar
 documentation: ug
 ---
 
-# How to add Syncfusion Calendar widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Calendar widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Calendar widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_calendar/example) tab in [Syncfusion Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_calendar/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Calendar](https://pub.dev/packages/syncfusion_flutter_calendar) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/calendar/overview.md
+++ b/Flutter/calendar/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Event Calendar (SfCalendar) Overview
 
-The Syncfusion Flutter Calendar library was written natively in Dart and has nine types of built-in configurable view modes that provide basic functionality for scheduling, managing, and representing appointments efficiently. The Calendar Widget exposes a clean and convenient user interface for custom working days and hours and basic calendar operations such as date navigation and selection.
+The Syncfusion<sup>&reg;</sup> Flutter Calendar library was written natively in Dart and has nine types of built-in configurable view modes that provide basic functionality for scheduling, managing, and representing appointments efficiently. The Calendar Widget exposes a clean and convenient user interface for custom working days and hours and basic calendar operations such as date navigation and selection.
 
 ![Calendar overview](images/overview/calendar_overview.png)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to(Calendar)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/af02d08d-129a-44c6-8401-e9d36c0125ac)|![image](https://github.com/user-attachments/assets/a6ad41e9-a747-45de-92e1-49dedeb99cfb)|
|![image](https://github.com/user-attachments/assets/2eda966c-2e29-4506-b168-657b95007ecd)|![image](https://github.com/user-attachments/assets/bba0802f-942a-401f-adc0-98402815ad6e)|
|![image](https://github.com/user-attachments/assets/010b6863-8630-4234-b994-a8269f9f0ff7)|![image](https://github.com/user-attachments/assets/e20b6a48-d0d2-4ee1-ba4e-6af745724b9b)|
|![image](https://github.com/user-attachments/assets/ff53bf1c-0b12-40d1-9c3f-f735d4d3d849)|![image](https://github.com/user-attachments/assets/f2d00b82-4a7a-4a67-98a5-148fa4770c9d)|

**getting-started(Calendar)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/31b99d92-f2d3-4b7e-9ef2-50076bda6139)|![image](https://github.com/user-attachments/assets/51d6d404-ada4-46c9-b122-056f1be973d4)|
|![image](https://github.com/user-attachments/assets/bb601437-02f4-4fd1-8edf-cf10e7405384)|![image](https://github.com/user-attachments/assets/9f0bcc5d-399c-4de7-8cb1-fd6ca4bac817)|

**overview(Calendar)**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/57d36043-a143-44ab-9040-64ecb96b6b70)|![image](https://github.com/user-attachments/assets/b6a49b4f-73fe-432a-a88a-0b42c4331968)|
