### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for chat

### DIFF
--- a/Flutter/chat/overview.md
+++ b/Flutter/chat/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Chat (SfChat) Overview
 
-The Syncfusion Flutter Chat widget displays conversations between two or more users and offers a wide range of customization options, including the composer, action button, and message bubbles (header, footer, content, and avatar).
+The Syncfusion<sup>&reg;</sup> Flutter Chat widget displays conversations between two or more users and offers a wide range of customization options, including the composer, action button, and message bubbles (header, footer, content, and avatar).
 
 ![Chat overview](images/overview/chat-overview.gif)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**overiew**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/c745cc13-f0c6-4150-8808-1134f228b5e0)|![image](https://github.com/user-attachments/assets/f7db1a97-4b44-4ef2-acc6-19c86d3d8044)|