### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for circular chart

### DIFF
--- a/Flutter/circular-charts/charts-type.md
+++ b/Flutter/circular-charts/charts-type.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Chart Types in Flutter Circular Charts (SfCircularChart)
 
-This page helps to navigate to the Chart types available in the Syncfusion Flutter Circular Charts widgets.
+This page helps to navigate to the Chart types available in the Syncfusion<sup>&reg;</sup> Flutter Circular Charts widgets.
 
 <table>
 	<tr>

--- a/Flutter/circular-charts/getting-started.md
+++ b/Flutter/circular-charts/getting-started.md
@@ -22,7 +22,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion [Flutter Chart](https://www.syncfusion.com/flutter-widgets/flutter-charts) dependency to your pub spec file.
+Add the Syncfusion<sup>&reg;</sup> [Flutter Chart](https://www.syncfusion.com/flutter-widgets/flutter-charts) dependency to your pub spec file.
 
 {% tabs %}
 {% highlight dart %} 

--- a/Flutter/circular-charts/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/circular-charts/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: Chart
 documentation: ug
 ---
 
-# How to add Syncfusion Circular Chart widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Circular Chart widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Circular Chart widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_charts/example) tab in [Syncfusion Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_charts/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Charts](https://pub.dev/packages/syncfusion_flutter_charts) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/circular-charts/overview.md
+++ b/Flutter/circular-charts/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Circular Charts (SfCircularChart) Overview
 
-Syncfusion Flutter Circular Charts (SfCircularChart) widget is written natively in Dart for creating beautiful and high-performance Circular charts, which are used to craft high-quality applications using Flutter.
+Syncfusion<sup>&reg;</sup> Flutter Circular Charts (SfCircularChart) widget is written natively in Dart for creating beautiful and high-performance Circular charts, which are used to craft high-quality applications using Flutter.
 
 ![Overview Flutter chart](images/overview/overview.png)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/254e50ec-70e0-4201-aa6d-fa616ce52117)|![image](https://github.com/user-attachments/assets/218513e8-59f5-490e-9bdb-74c4ad5f2dc6)|
|![image](https://github.com/user-attachments/assets/7e969a5b-7a12-42bd-a3a6-45c5543da181)|![image](https://github.com/user-attachments/assets/ce39c658-c7d3-47c6-b39a-e7ae9dc3db02)|
|![image](https://github.com/user-attachments/assets/95b8741c-6580-4a23-bf33-74495f5e638f)|![image](https://github.com/user-attachments/assets/e0e7f576-504a-459b-addc-1b96eb20c82a)|
|![image](https://github.com/user-attachments/assets/4c1b89bd-e3a7-4308-b1e2-2e2670d9325c)|![image](https://github.com/user-attachments/assets/288594ed-6f50-40b7-97b2-ad1a68728edc)|

**charts-type**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/24fc2ab4-50cb-4864-92ac-85c7f0ee2afb)|![image](https://github.com/user-attachments/assets/82f0e4d9-0904-4652-850e-030d41726bc8)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/0bebceaf-2d7b-4708-a541-f56c424bb7f5)|![image](https://github.com/user-attachments/assets/53d70189-1bc0-4430-b500-ea680c912c69)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/9790d106-7fc0-482c-9287-ef02018b35e5)|![image](https://github.com/user-attachments/assets/2869dec0-36cb-45c7-99b9-bb2139444437)|
