### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for date range picker

### DIFF
--- a/Flutter/DateRangePicker/getting-started.md
+++ b/Flutter/DateRangePicker/getting-started.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 # Getting started with Flutter Date Range Picker (SfDateRangePicker)
-This section explains the steps required to add the [date range picker](https://www.syncfusion.com/flutter-widgets/flutter-daterangepicker) widget. This section covers only basic features needed to get started with Syncfusion date range picker widget.
+This section explains the steps required to add the [date range picker](https://www.syncfusion.com/flutter-widgets/flutter-daterangepicker) widget. This section covers only basic features needed to get started with Syncfusion<sup>&reg;</sup> date range picker widget.
 
 To get start quickly with our Flutter date range picker widget, you can check on this video.
 
@@ -20,7 +20,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter date range picker dependency to your `pubspec.yaml` file.
+Add the Syncfusion<sup>&reg;</sup> Flutter date range picker dependency to your `pubspec.yaml` file.
 
 {% highlight dart %}
 

--- a/Flutter/DateRangePicker/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/DateRangePicker/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfDateRangePicker
 documentation: ug
 ---
 
-# How to add Syncfusion DateRangePicker widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> DateRangePicker widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add DateRangePicker widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_datepicker/example) tab in [Syncfusion Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_datepicker/example) tab in [Syncfusion<sup>&reg;</sup> Flutter DatePicker](https://pub.dev/packages/syncfusion_flutter_datepicker) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/DateRangePicker/overview.md
+++ b/Flutter/DateRangePicker/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Date Range Picker (SfDateRangePicker) Overview
 
-The Syncfusion Flutter Date Range Picker is a lightweight widget that allows users to easily select a single date, multiple dates, or a range of dates. It provides month, year, decade, and century view options to quickly navigate to the desired date. It supports minimum, maximum, and disabled dates to restrict date selection.
+The Syncfusion<sup>&reg;</sup> Flutter Date Range Picker is a lightweight widget that allows users to easily select a single date, multiple dates, or a range of dates. It provides month, year, decade, and century view options to quickly navigate to the desired date. It supports minimum, maximum, and disabled dates to restrict date selection.
 
 
 ## Key features


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/1f7ba131-2c42-4118-83a5-f61654d262a8)|![image](https://github.com/user-attachments/assets/4dc947c0-5c9c-4bfd-9ff9-18bc09af02cc)|
|![image](https://github.com/user-attachments/assets/01dc87f3-d518-4725-8452-1bd34150805c)|![image](https://github.com/user-attachments/assets/d90b1bee-8733-43b6-993c-7efc24eb8273)|
|![image](https://github.com/user-attachments/assets/7ab7ed3d-d0c9-466e-8e89-bea7ce41f174)|![image](https://github.com/user-attachments/assets/0612828c-b3d2-464b-b3f7-9e73eec768f6)|
|![image](https://github.com/user-attachments/assets/2b827c5f-9451-48a6-885b-e028a27d32d4)|![image](https://github.com/user-attachments/assets/3d1b752f-1be0-441d-9d6b-8e69c82c2058)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/ad498aaf-96b5-42cd-8500-7dc4aabe6aac)|![image](https://github.com/user-attachments/assets/778589bf-bdaf-43e8-94a8-df6909b027d4)|
|![image](https://github.com/user-attachments/assets/cdca8080-f568-4f25-8153-8dd0af2e65d8)|![image](https://github.com/user-attachments/assets/1149d517-c599-4a7a-8b59-83e501a59e7f)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/455c6407-de61-4286-b840-51c228767e9f)|![image](https://github.com/user-attachments/assets/f1a06315-f4c6-4689-9701-fc42edb2c3e8)|
