### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for introduction and licensing

### DIFF
--- a/Flutter/Licensing/overview.md
+++ b/Flutter/Licensing/overview.md
@@ -8,13 +8,13 @@ documentation: ug
 ---
 
 
-# Syncfusion Licensing Overview
+# Syncfusion<sup>&reg;</sup> Licensing Overview
 
-The License key registration is no longer required for Flutter from version 18.3.0.x. So, there is no need to generate or register Syncfusion Flutter license keys in your Flutter projects. 
+The License key registration is no longer required for Flutter from version 18.3.0.x. So, there is no need to generate or register Syncfusion<sup>&reg;</sup> Flutter license keys in your Flutter projects. 
 
-The Flutter controls from Syncfusion can be used without registering the license keys.
+The Flutter controls from Syncfusion<sup>&reg;</sup> can be used without registering the license keys.
 
->**Note**: If you are using Syncfusion controls prior to version 18.3.0.x, please follow the following steps to register your license key.
+>**Note**: If you are using Syncfusion<sup>&reg;</sup> controls prior to version 18.3.0.x, please follow the following steps to register your license key.
 
 ## How To Register In An Application
 

--- a/Flutter/introduction/api-reference.md
+++ b/Flutter/introduction/api-reference.md
@@ -7,9 +7,9 @@ control: API
 documentation: ug
 ---
 
-# Syncfusion Flutter Widgets - API reference
+# Syncfusion<sup>&reg;</sup> Flutter Widgets - API reference
 
-This page helps to navigate to the public API's available in the Syncfusion Flutter widgets.
+This page helps to navigate to the public API's available in the Syncfusion<sup>&reg;</sup> Flutter widgets.
 
 <table>
     <tr>

--- a/Flutter/introduction/overview.md
+++ b/Flutter/introduction/overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About Essential Studio<sup>&reg;</sup> Flutter | Syncfusion
 description: Learn here all about introduction of Syncfusion Essential Studio<sup>&reg;</sup> Flutter, its elements, features and more.
-platform: Flutter
+platform: flutter
 control: Overview
 documentation: ug
 ---

--- a/Flutter/introduction/overview.md
+++ b/Flutter/introduction/overview.md
@@ -7,9 +7,9 @@ control: Overview
 documentation: ug
 ---
 
-# Introduction to Syncfusion Flutter Widgets Documentation
+# Introduction to Syncfusion<sup>&reg;</sup> Flutter Widgets Documentation
 
-The Syncfusion [Flutter Widgets](https://www.syncfusion.com/flutter-widgets) are a set of [advanced custom widgets and file formats packages](https://pub.dev/publishers/syncfusion.com/packages) needed to create rich and high-quality cross-platform applications in iOS, Android, and Web using a single code base. This article gives you a quick overview of how to read the Flutter widgets documentation and other help resources such as video tutorials, code examples, demos, and the knowledge base.
+The Syncfusion<sup>&reg;</sup> [Flutter Widgets](https://www.syncfusion.com/flutter-widgets) are a set of [advanced custom widgets and file formats packages](https://pub.dev/publishers/syncfusion.com/packages) needed to create rich and high-quality cross-platform applications in iOS, Android, and Web using a single code base. This article gives you a quick overview of how to read the Flutter widgets documentation and other help resources such as video tutorials, code examples, demos, and the knowledge base.
 
 ## How to best read this user guide
 

--- a/Flutter/introduction/overview.md
+++ b/Flutter/introduction/overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About Essential Studio<sup>&reg;</sup> Flutter | Syncfusion
 description: Learn here all about introduction of Syncfusion Essential Studio<sup>&reg;</sup> Flutter, its elements, features and more.
-platform: flutter
+platform: Flutter
 control: Overview
 documentation: ug
 ---

--- a/Flutter/introduction/widgets-catalog.md
+++ b/Flutter/introduction/widgets-catalog.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Widgets Catalog
 
-The Syncfusion Flutter cross platform UI widgets and libraries are an ideal choice for developing rich cross platform iOS, Android, and Web applications from a single shared code base. You can build responsive, interactive, and creative application that run on multiple platforms and devices with various form factors. Some of the cool features like theming and customization options makes the widgets perfect for your cross-platform application.
+The Syncfusion<sup>&reg;</sup> Flutter cross platform UI widgets and libraries are an ideal choice for developing rich cross platform iOS, Android, and Web applications from a single shared code base. You can build responsive, interactive, and creative application that run on multiple platforms and devices with various form factors. Some of the cool features like theming and customization options makes the widgets perfect for your cross-platform application.
 
 This section provides the user guide link for each widget and its package link.
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**Introduction**
**api-reference**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/c8e38766-4d1b-4b2a-a64e-d2e3843790a2)|![image](https://github.com/user-attachments/assets/ca11c970-21f3-461e-b1f7-0a465ef327d2)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/55dd5c3a-fc09-4179-8586-31b49497e3e8)|![image](https://github.com/user-attachments/assets/db8f799d-b73f-41d5-9e6c-f4e86095ec87)|

**widget-catalog**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/a88135ae-6399-45c8-9d0c-76db563c03dd)|![image](https://github.com/user-attachments/assets/af44f4cb-4153-4e4b-8c29-a572e24423ff)|

**licensing**
**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/9aea39d4-97ee-42d0-9997-93132b617e66)|![image](https://github.com/user-attachments/assets/d488e206-948f-4d9b-bbd4-848b3c7c756f)|
