### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for linear gauge

### DIFF
--- a/Flutter/linear-gauge/getting-started.md
+++ b/Flutter/linear-gauge/getting-started.md
@@ -22,7 +22,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter Gauge dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter Gauge dependency to your pubspec.yaml file.
 
 {% highlight dart %} 
 

--- a/Flutter/linear-gauge/getting-started.md
+++ b/Flutter/linear-gauge/getting-started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting started with Flutter Linear Gauge widget | Syncfusion
 description: Learn here about getting started with Syncfusion Flutter Linear Gauge (SfLinearGauge) widget, its elements, and more. 
-platform: Flutter
+platform: flutter
 control: SfLinearGauge
 documentation: ug
 ---

--- a/Flutter/linear-gauge/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/linear-gauge/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfLinearGauge
 documentation: ug
 ---
 
-# How to add Syncfusion Linear Gauge widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Linear Gauge widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Linear Gauge widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_gauges/example) tab in [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_gauges/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/linear-gauge/overview.md
+++ b/Flutter/linear-gauge/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Linear Gauge (SfLinearGauge) Overview
 
-Syncfusion Flutter Linear Gauge is a data visualization widget to display data on a linear scale. Use this widget to craft high-quality mobile app user interfaces.
+Syncfusion<sup>&reg;</sup> Flutter Linear Gauge is a data visualization widget to display data on a linear scale. Use this widget to craft high-quality mobile app user interfaces.
 
 ![Overview flutter linear gauge](images/basic_elements.png)
 

--- a/Flutter/linear-gauge/overview.md
+++ b/Flutter/linear-gauge/overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About Flutter Linear Gauge widget | Syncfusion
 description: Learn here all about introduction of Syncfusion Flutter Linear Gauge (SfLinearGauge) widget, its features, and more.
-platform: Flutter
+platform: flutter
 control: SfLinearGauge
 documentation: ug
 ---


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/05c6002f-499d-406b-8571-8fd39e890789)|![image](https://github.com/user-attachments/assets/058b303c-dedd-4958-9c67-42d625775f82)|
|![image](https://github.com/user-attachments/assets/ad3a64b3-478d-4455-8cfb-914221be8118)|![image](https://github.com/user-attachments/assets/2ee01155-2d20-49fa-9cef-6d3a15ccfa09)|
|![image](https://github.com/user-attachments/assets/5f9ea5ac-b6bf-4d8f-a8ff-d9245e489463)|![image](https://github.com/user-attachments/assets/13fe49ee-a2ca-44c6-80d1-4ab0640cfb4f)|
|![image](https://github.com/user-attachments/assets/8171aa8a-2c32-40dd-abeb-515916d77802)|![image](https://github.com/user-attachments/assets/f7f38783-5475-47e1-b53b-d51e6497e75f)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/1ff2ed4e-f099-409c-9af5-7bd2da79f6ea)|![image](https://github.com/user-attachments/assets/e7ce01ee-c7e6-4c6c-907b-b36f06f3c84d)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/c0f6cbf6-96c3-439c-9ed3-9885d423f875)|![image](https://github.com/user-attachments/assets/47ddd77c-3d11-4479-aadd-c4664723a2b5)|
