### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for radial gauge

### DIFF
--- a/Flutter/radial-gauge/getting-started.md
+++ b/Flutter/radial-gauge/getting-started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting started with Flutter Radial Gauge widget | Syncfusion
 description: Learn here about getting started with Syncfusion Flutter Radial Gauge (SfRadialGauge) control, its elements, and more. 
-platform: Flutter
+platform: flutter
 control: SfRadialGauge
 documentation: ug
 ---

--- a/Flutter/radial-gauge/getting-started.md
+++ b/Flutter/radial-gauge/getting-started.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Getting started with Flutter Radial Gauge (SfRadialGauge)
 
-This section explains the steps required to add the Flutter [Radial Gauge](https://www.syncfusion.com/flutter-widgets/flutter-radial-gauge) and its elements such as title, axis, range, pointer and annotation. This section covers only basic features needed to know to get started with Syncfusion radial gauge. 
+This section explains the steps required to add the Flutter [Radial Gauge](https://www.syncfusion.com/flutter-widgets/flutter-radial-gauge) and its elements such as title, axis, range, pointer and annotation. This section covers only basic features needed to know to get started with Syncfusion<sup>&reg;</sup> radial gauge. 
 
 To get start quickly with our Flutter radial gauge widget, you can check on this video.
 
@@ -22,7 +22,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter Gauge dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter Gauge dependency to your pubspec.yaml file.
 
 {% highlight dart %} 
 

--- a/Flutter/radial-gauge/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/radial-gauge/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfRadialGauge
 documentation: ug
 ---
 
-# How to add Syncfusion Radial Gauge widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Radial Gauge widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Radial Gauge widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_gauges/example) tab in [Syncfusion Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_gauges/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Gauges](https://pub.dev/packages/syncfusion_flutter_gauges) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/radial-gauge/overview.md
+++ b/Flutter/radial-gauge/overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About Flutter Radial Gauge widget | Syncfusion
 description: Learn here all about introduction of Syncfusion Flutter Radial Gauge (SfRadialGauge) widget, its features, and more.
-platform: Flutter
+platform: flutter
 control: SfRadialGauge
 documentation: ug
 ---

--- a/Flutter/radial-gauge/overview.md
+++ b/Flutter/radial-gauge/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter Radial Gauge (SfRadialGauge) Overview
 
-Syncfusion Flutter Radial Gauge is a data visualization widget, which is written in dart, to create modern, interactive, and animated gauge that is used to craft high-quality mobile app user interfaces using Flutter.
+Syncfusion<sup>&reg;</sup> Flutter Radial Gauge is a data visualization widget, which is written in dart, to create modern, interactive, and animated gauge that is used to craft high-quality mobile app user interfaces using Flutter.
 
 ![Overview flutter radial gauge](images/overview/gauge_overview.png)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/7fcc9e0b-b7bf-4f15-8d71-b5eceb2784d6)|![image](https://github.com/user-attachments/assets/51b5432e-8db3-49e6-a143-9fce0e3e3bb3)|
|![image](https://github.com/user-attachments/assets/d7eb443d-f9d4-47aa-b102-8ef9d3301ccb)|![image](https://github.com/user-attachments/assets/631703fe-eef2-45b5-8424-f7597ee01129)|
|![image](https://github.com/user-attachments/assets/31db60c0-5836-45d4-a98a-795a80bc9c37)|![image](https://github.com/user-attachments/assets/6895a235-2ad1-4619-94cf-fef1204afe00)|
|![image](https://github.com/user-attachments/assets/cac9bd37-6655-4f0f-94b1-f2150336edfe)|![image](https://github.com/user-attachments/assets/705d5c57-ec9f-455d-878f-446590a7ddd6)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/ea8f3a04-b7eb-4ef5-93a9-9e7bb19f54d4)|![image](https://github.com/user-attachments/assets/d77d51ac-b99c-4427-8e4a-8d8007e7e772)|
|![image](https://github.com/user-attachments/assets/323a00a0-36a2-40eb-be06-dc833af58ca8)|![image](https://github.com/user-attachments/assets/3f66ed2b-8f07-4085-9544-f2c9124b3366)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/e662a3bb-4657-4265-b3d1-7a1fb8ba0be2)|![image](https://github.com/user-attachments/assets/ef779209-dea7-4d99-ae89-108acf43294b)|
