### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for maps

### DIFF
--- a/Flutter/maps/getting-started.md
+++ b/Flutter/maps/getting-started.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Getting started with Flutter Maps widget | Syncfusion
 description: Learn here about getting started with Syncfusion Flutter Maps (SfMaps) widget, its elements, and more.
-platform: Flutter
+platform: flutter
 control: SfMaps
 documentation: ug
 ---

--- a/Flutter/maps/getting-started.md
+++ b/Flutter/maps/getting-started.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 # Getting started with Flutter Maps (SfMaps)
-This section explains the steps required to add the maps widget with shape layer and its elements such as data labels, tooltip, assignable colors based on region, and legends. It also explains about adding tile layer with OpenStreetMap. This section covers only basic features needed to know to get started with Syncfusion maps.
+This section explains the steps required to add the maps widget with shape layer and its elements such as data labels, tooltip, assignable colors based on region, and legends. It also explains about adding tile layer with OpenStreetMap. This section covers only basic features needed to know to get started with Syncfusion<sup>&reg;</sup> maps.
 
 To get start quickly with our Flutter Maps widget, you can check on this video.
 
@@ -20,7 +20,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter maps dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter maps dependency to your pubspec.yaml file.
 
 {% highlight dart %}
 

--- a/Flutter/maps/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/maps/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfMaps
 documentation: ug
 ---
 
-# How to add Syncfusion Maps widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> Maps widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add Maps widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_maps/example) tab in [Syncfusion Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_maps/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Maps](https://pub.dev/packages/syncfusion_flutter_maps) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/c6f03921-835c-4738-9fe6-4feadbbd5898)|![image](https://github.com/user-attachments/assets/d5a9a915-c625-4fe7-a886-cc3649c345d0)|
|![image](https://github.com/user-attachments/assets/77dfb487-42c7-486a-85b4-30652d8a9178)|![image](https://github.com/user-attachments/assets/c30af46f-5628-481d-869d-c93ecc620847)|
|![image](https://github.com/user-attachments/assets/e450640e-6b2e-4e00-85d8-0ffe833ca0c8)|![image](https://github.com/user-attachments/assets/692af540-5877-4830-8280-bff206f4110f)|
|![image](https://github.com/user-attachments/assets/2d424336-64b3-471b-9235-eacf7749aaf1)|![image](https://github.com/user-attachments/assets/0b381881-6d0f-4f0c-852c-75be15bfb494)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/a36a7c54-b0f0-4289-87e5-d58e59e8cfa5)|![image](https://github.com/user-attachments/assets/d3c2d1c6-38e0-4c41-aae3-10d7d255b55f)|
|![image](https://github.com/user-attachments/assets/ecf4b43a-184d-4056-9e47-3adb1aefef87)|![image](https://github.com/user-attachments/assets/9b4afdc0-b9c0-4dd2-8329-c7f0e8d15a7c)|  
