### PR TITLE
FLUT-927176 - [Others] Added trademark symbol for range selector

### DIFF
--- a/Flutter/range-selector/getting-started.md
+++ b/Flutter/range-selector/getting-started.md
@@ -8,7 +8,7 @@ documentation: ug
 ---
 
 # Getting started with Flutter Range Selector (SfRangeSelector)
-This section explains the steps required to add the range selector widget and its elements such as numeric and date values, ticks, labels and tooltips. This section covers only basic features needed to know to get started with Syncfusion range selector.
+This section explains the steps required to add the range selector widget and its elements such as numeric and date values, ticks, labels and tooltips. This section covers only basic features needed to know to get started with Syncfusion<sup>&reg;</sup> range selector.
 
 To get start quickly with our Flutter Range Selector widget, you can check on this video.
 
@@ -20,7 +20,7 @@ Create a simple project using the instructions given in the [Getting Started wit
 
 **Add dependency**
 
-Add the Syncfusion Flutter range selector dependency to your pubspec.yaml file.
+Add the Syncfusion<sup>&reg;</sup> Flutter range selector dependency to your pubspec.yaml file.
 
 {% highlight dart %}
 

--- a/Flutter/range-selector/how-to/custom-widget-on-flutterflow.md
+++ b/Flutter/range-selector/how-to/custom-widget-on-flutterflow.md
@@ -7,7 +7,7 @@ control: SfRangeSelector
 documentation: ug
 ---
 
-# How to add Syncfusion RangeSelector widget in FlutterFlow?
+# How to add Syncfusion<sup>&reg;</sup> RangeSelector widget in FlutterFlow?
 
 ## Overview
 
@@ -31,28 +31,28 @@ Navigate to the [FlutterFlow dashboard](https://app.flutterflow.io/dashboard) an
 ### Add RangeSelector widget as a dependency
 
 1. Click on `+ Add Dependency`, a text editor will appear.
-2. Navigate to [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
+2. Navigate to [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) in [pub.dev](https://pub.dev/) and copy the dependency name and version using the `Copy to Clipboard` option.
 ![Version](how-to-section-images/copy-version.png)
 3. Paste the copied dependency into the text editor, then click `Refresh` and `Save` it.
 
->**Note**: The live version of [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
+>**Note**: The live version of [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) has been migrated to the latest version of Flutter SDK. To ensure compatibility, check [FlutterFlow](https://app.flutterflow.io/dashboard)'s current Flutter version and obtain the corresponding version of [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) by referring to the [SDK compatibility](https://help.syncfusion.com/flutter/system-requirements#sdk-version-compatibility).
 
 ![Dependency](how-to-section-images/dependency.png)
 
 >**Note**: If you are using an older version of a dependency instead of the latest one, remove the caret symbol (^) prefix in the version number after pasting the dependency. For example, change `^21.3.0` to `21.3.0`.
 
->**Note**: Since [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) depends on the [Syncfusion Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
+>**Note**: Since [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) depends on the [Syncfusion<sup>&reg;</sup> Flutter Core](https://pub.dev/packages/syncfusion_flutter_core) package, make sure to add it as a dependency following the same steps mentioned above.
 
 ### Import the package
 
-1. Navigate to the `Installing` tab on the [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) page. Under the `Import it` section, copy the package import statement.
+1. Navigate to the `Installing` tab on the [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) page. Under the `Import it` section, copy the package import statement.
 ![Package](how-to-section-images/copy-package.png)
 2. Paste the copied import statement into the code editor and then `Save` it.
 ![Import](how-to-section-images/import-package-flutterflow.png)
 
 ### Add widget code snippet in code editor
 
-1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_sliders/example) tab in [Syncfusion Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) and copy the widget specific codes.
+1. Navigate to the [Example](https://pub.dev/packages/syncfusion_flutter_sliders/example) tab in [Syncfusion<sup>&reg;</sup> Flutter Sliders](https://pub.dev/packages/syncfusion_flutter_sliders) and copy the widget specific codes.
 ![Code](how-to-section-images/code-snippet.png)
 2. Paste the copied code sample into the code editor, click `Format Code`, and `Save` it.
 ![Code snippet](how-to-section-images/Adding-code-snippent.png)

--- a/Flutter/range-selector/overview.md
+++ b/Flutter/range-selector/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Flutter range selector (SfRangeSelector) Overview
 
-Syncfusion Flutter Range Selector is a highly interactive UI widget for selecting a smaller range from a larger data set. It provides a rich set of features such as numeric and date values, labels, ticks, dividers, and tooltips. It also supports adding any type of widget as content.
+Syncfusion<sup>&reg;</sup> Flutter Range Selector is a highly interactive UI widget for selecting a smaller range from a larger data set. It provides a rich set of features such as numeric and date values, labels, ticks, dividers, and tooltips. It also supports adding any type of widget as content.
 
 ![Range selector overview](images/overview/range-selector-overview.png)
 


### PR DESCRIPTION
## Description ##

Updated trademark symbol to the Syncfusion's, Syncfusion and Syncfusion Essential Studio keywords in all files.

**how-to**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/81abae0d-9adb-46d8-98ed-e6c0d0c591be)|![image](https://github.com/user-attachments/assets/147f2373-4afb-4c75-9062-0f7dc0b46f30)|
|![image](https://github.com/user-attachments/assets/0c18be60-0b02-4c15-a6f2-59df684f4956)|![image](https://github.com/user-attachments/assets/e2c39396-1767-49b1-ab12-9d64e82b33cd)|
|![image](https://github.com/user-attachments/assets/675b21c0-94de-4bb1-b1d0-43c0aa4da404)|![image](https://github.com/user-attachments/assets/d6473d65-d884-4889-af5b-6730f31b1150)|
|![image](https://github.com/user-attachments/assets/fddbdf2b-e83c-4870-a7ea-06ddf595a239)|![image](https://github.com/user-attachments/assets/23625b9c-8d84-4c4c-8e83-10ec11c99cae)|

**getting-started**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/7d55ba18-6ee5-4277-94b0-c2e0e9d10058)|![image](https://github.com/user-attachments/assets/b20ec269-7764-481c-b997-de3b933075ff)|
|![image](https://github.com/user-attachments/assets/e8663bef-a023-4a67-b5a3-71793029cb8a)|![image](https://github.com/user-attachments/assets/cbbffa9b-e7c9-445e-9715-4bfb339d2710)|

**overview**
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/ae34f2f6-8edd-4d49-a256-c63b90b584d0)|![image](https://github.com/user-attachments/assets/690ad0b7-adc4-45c5-bc0a-a7a7c273dccc)|
