### PR TITLE
FLUT-927176 - [Others] Added tutorial samples in user guide

### DIFF
--- a/Flutter/slider/basic-features.md
+++ b/Flutter/slider/basic-features.md
@@ -477,3 +477,8 @@ Widget build(BuildContext context) {
 * Labels and dividers - [`Link`](https://help.syncfusion.com/flutter/slider/labels-and-divider)
 * Tooltip - [`Link`](https://help.syncfusion.com/flutter/slider/tooltip)
 * Thumb and overlay - [`Link`](https://help.syncfusion.com/flutter/slider/thumb-and-overlay)
+
+To know more about how to customize both thumb and divider in the Flutter Slider, you can watch this video.
+
+<style>#FlutterSliderVideoTutorial{width : 90% !important; height: 300px !important }</style>
+<iframe id='FlutterSliderVideoTutorial' src='https://www.youtube.com/embed/IVRfO1qDom8'></iframe>

--- a/Flutter/slider/getting-started.md
+++ b/Flutter/slider/getting-started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting started with Flutter Slider widget | Syncfusion
 description: Learn here about getting started with Syncfusion Flutter Slider (SfSlider) widget, its elements, and more.
-platform: Flutter
+platform: flutter
 control: SfSlider
 documentation: ug
 ---

--- a/Flutter/slider/labels-and-divider.md
+++ b/Flutter/slider/labels-and-divider.md
@@ -2,7 +2,7 @@
 layout: post
 title: Labels and Dividers in Flutter Slider widget | Syncfusion
 description: Learn here all about the Labels and Dividers feature of Syncfusion Flutter Slider (SfSlider) widget and more.
-platform: Flutter
+platform: flutter
 control: SfSlider
 documentation: ug
 ---

--- a/Flutter/slider/labels-and-divider.md
+++ b/Flutter/slider/labels-and-divider.md
@@ -7,7 +7,7 @@ control: SfSlider
 documentation: ug
 ---
 
-# Labels and Dividers in Flutter Treemap (SfTreemap)
+# Labels and Dividers in Flutter Slider (SfSlider)
 This section explains about how to add the labels and dividers in the slider.
 
 ## Show labels


### PR DESCRIPTION
## Description ##

Updated one published YouTube video tutorial sample in user guide for Flutter Slider in the basic features page.

**SfSlider** - How to customize thumb and divider in Flutter Slider?

![image](https://github.com/user-attachments/assets/663db94c-d961-4743-b21f-140012cbc8d1)


Also modified the heading text in the Labels and Divider file as the title of this respective section is wrong. Instead of Slider, it is mentioned as Treemap.

**Before:**
![image](https://github.com/user-attachments/assets/3a9129a3-6f11-4589-a7f7-7469c726e732)

**After:**
![image](https://github.com/user-attachments/assets/9da75503-a9fb-4cbd-9660-e18521751a84)