### PR TITLE
SEO-202684-Flutter-Datagrid-Description too short

### DIFF
--- a/Flutter/datagrid/data-binding.md
+++ b/Flutter/datagrid/data-binding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Data Binding in Flutter DataGrid | DataTable | Syncfusion
-description: Learn how to set the Data source for Syncfusion Flutter DataGrid (SfDataGrid) widget and more.
+description: Checkout and Learn how to set the Data source for Syncfusion Flutter DataGrid (SfDataGrid) widget and more.
 platform: flutter
 control: SfDataGrid
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/flutter-docs/pull/1246 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link||

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary