### PR TITLE
FLUT-979460 - [Others] Added the 2025 Volume 4 weekly patch release notes in Flutter 

### DIFF
--- a/Flutter/Release-notes/v31.1.20.md
+++ b/Flutter/Release-notes/v31.1.20.md
@@ -15,6 +15,10 @@ documentation: ug
 
 {% enddirectory %}
 
+## General
+
+* The compatible version of all our Flutter widgets has been updated to Flutter SDK 3.35.
+
 ## Test Results
 
 | Component Name | Test Cases | Passed | Failed | Remarks |

--- a/Flutter/Release-notes/v31.2.10.md
+++ b/Flutter/Release-notes/v31.2.10.md
@@ -15,6 +15,28 @@ documentation: ug
 
 {% enddirectory %}
 
+## Calendar 
+
+### Breaking changes
+
+* #FB70575 - The [leadingDateTextStyle](https://pub.dev/documentation/syncfusion_flutter_calendar/latest/calendar/MonthCellStyle/leadingDatesTextStyle.html) now applies to dates in the previous month, while the [trailingDateTextStyle](https://pub.dev/documentation/syncfusion_flutter_calendar/latest/calendar/MonthCellStyle/trailingDatesTextStyle.html) applies to dates in the next month in the month view.
+
+### Enhancements
+
+* #FB70566 - The display of exceeding events has been improved for all-day events with [appointmentBuilder](https://pub.dev/documentation/syncfusion_flutter_calendar/latest/calendar/SfCalendar/appointmentBuilder.html) customization.
+
+## Localizaitons
+
+### Enhancements
+
+* The translation for “No events” has been modified to “Etkinlik yok” from “Olay yok” for Turkish language.
+
+## Radial Gauge
+
+### Bug fixes
+
+* Now, the [MarkerPointer](https://pub.dev/documentation/syncfusion_flutter_gauges/latest/gauges/MarkerPointer-class.html) image will render properly without any clipping issues.
+
 ## Test Results
 
 | Component Name | Test Cases | Passed | Failed | Remarks |

--- a/Flutter/Release-notes/v31.2.10.md
+++ b/Flutter/Release-notes/v31.2.10.md
@@ -25,7 +25,7 @@ documentation: ug
 
 * #FB70566 - The display of exceeding events has been improved for all-day events with [appointmentBuilder](https://pub.dev/documentation/syncfusion_flutter_calendar/latest/calendar/SfCalendar/appointmentBuilder.html) customization.
 
-## Localizaitons
+## Localizations
 
 ### Enhancements
 


### PR DESCRIPTION
### Description ###

I have added the 2025 Volume 4 weekly patch release notes for versions v31.1.10 and v31.2.20 in Flutter.
I referred to the changelog for the weekly release changes and updated the release notes accordingly.
Reference link: https://pub.dev/packages/syncfusion_flutter_calendar/changelog

### Changes added ###

**Version: 31.1.10:**
<img width="1262" height="390" alt="image" src="https://github.com/user-attachments/assets/9bd3f7c3-9644-4625-a883-925a950f88d7" />

**Version 32.2.20:**
<img width="1393" height="893" alt="image" src="https://github.com/user-attachments/assets/8a99c18e-5a8a-452d-a854-ca4c9a994098" />

