### PR TITLE
Modified Flutter SfDataGrid User Guide API links 

### DIFF
--- a/Flutter/datagrid/accessibility.md
+++ b/Flutter/datagrid/accessibility.md
@@ -21,14 +21,14 @@ The [SfDataGrid](https://pub.dev/documentation/syncfusion_flutter_datagrid/lates
 
 The [SfDataGrid](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid-class.html) provides sufficient color contrast to make cell content more readable. Use the following properties to customize the appearance of the DataGrid elements:
 
-* [currentCellStyle](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/DataGridCurrentCellStyle-class.html)
-* [frozenPaneElevation](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/frozenPaneElevation.html)
-* [frozenPaneLineColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/frozenPaneLineColor.html)
-* [gridLineColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/gridLineColor.html)
-* [headerColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/headerColor.html)
-* [headerHoverColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/headerHoverColor.html)
-* [selectionColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/selectionColor.html)
-* [sortIconColor](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/sortIconColor.html)
+* [currentCellStyle](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/currentCellStyle.html)
+* [frozenPaneElevation](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/frozenPaneElevation.html)
+* [frozenPaneLineColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/frozenPaneLineColor.html)
+* [gridLineColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/gridLineColor.html)
+* [headerColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/headerColor.html)
+* [headerHoverColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/headerHoverColor.html)
+* [selectionColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/selectionColor.html)
+* [sortIconColor](https://pub.dev/documentation/syncfusion_flutter_core/latest/theme/SfDataGridThemeData/sortIconColor.html)
 
 ## Large fonts
 

--- a/Flutter/datagrid/pull-to-refresh.md
+++ b/Flutter/datagrid/pull-to-refresh.md
@@ -164,7 +164,7 @@ Download the demo application from [GitHub](https://github.com/SyncfusionExample
 
 ## Customizing the refresh indicator
 
-SfDataGrid displays the [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html) for `pull to refresh` action. So, set the color and background color of the refresh indicator by using the [ThemeData.accentColor](https://api.flutter.dev/flutter/material/ThemeData/accentColor.html) and  [ThemeData.canvasColor](https://api.flutter.dev/flutter/material/ThemeData/canvasColor.html) properties.
+SfDataGrid displays the [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html) for `pull to refresh` action. So, set the color and background color of the refresh indicator by using the `ThemeData.accentColor` and  [ThemeData.canvasColor](https://api.flutter.dev/flutter/material/ThemeData/canvasColor.html) properties.
 
 Also, change the stroke width and displacement of the refresh indicator by using the [SfDataGrid.refreshIndicatorStrokeWidth](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorStrokeWidth.html) and [SfDataGrid.refreshIndicatorDisplacement](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorDisplacement.html) properties.
 

--- a/Flutter/datagrid/pull-to-refresh.md
+++ b/Flutter/datagrid/pull-to-refresh.md
@@ -164,9 +164,11 @@ Download the demo application from [GitHub](https://github.com/SyncfusionExample
 
 ## Customizing the refresh indicator
 
-SfDataGrid displays the [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html) for `pull to refresh` action. So, set the color and background color of the refresh indicator by using the `ThemeData.accentColor` and  [ThemeData.canvasColor](https://api.flutter.dev/flutter/material/ThemeData/canvasColor.html) properties.
+SfDataGrid displays Flutter's [RefreshIndicator](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html) during pull-to-refresh actions. You can customize the refresh indicator by using the [SfDataGrid.refreshIndicatorStrokeWidth](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorStrokeWidth.html) and [SfDataGrid.refreshIndicatorDisplacement](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorDisplacement.html) properties.
 
-Also, change the stroke width and displacement of the refresh indicator by using the [SfDataGrid.refreshIndicatorStrokeWidth](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorStrokeWidth.html) and [SfDataGrid.refreshIndicatorDisplacement](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid/refreshIndicatorDisplacement.html) properties.
+To set the indicator's color and background color, use the [ColorScheme](https://api.flutter.dev/flutter/material/ColorScheme-class.html) properties within [ThemeData](https://api.flutter.dev/flutter/material/ThemeData-class.html). The `primary` color in ColorScheme controls the indicator's color.
+
+> **Note:** The deprecated `ThemeData.accentColor` property has been replaced with `ColorScheme.primary` in Flutter 3.0+. Use ColorScheme for modern Flutter applications.
 
 {% tabs %}
 {% highlight Dart %} 

--- a/Flutter/datagrid/right-to-left.md
+++ b/Flutter/datagrid/right-to-left.md
@@ -17,7 +17,7 @@ Right-to-left rendering can be switched in the following ways:
 
 ### Wrapping the SfDataGrid with the Directionality widget
 
-To change the rendering direction from right to left, wrap the [SfDataGrid](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid-class.html) widget inside the [Directionality](https://api.flutter.dev/flutter/widgets/Directionality-class.html) widget and set the [textDirection](https://api.flutter.dev/flutter/widgets/Directionality/textDirection.html) property as [TextDirection.rtl](https://api.flutter.dev/flutter/dart-ui/TextDirection-class.html).
+To change the rendering direction from right to left, wrap the [SfDataGrid](https://pub.dev/documentation/syncfusion_flutter_datagrid/latest/datagrid/SfDataGrid-class.html) widget inside the [Directionality](https://api.flutter.dev/flutter/widgets/Directionality-class.html) widget and set the [textDirection](https://api.flutter.dev/flutter/widgets/Directionality/textDirection.html) property as [TextDirection.rtl](https://api.flutter.dev/flutter/dart-ui/TextDirection.html#rtl).
 
 {% tabs %}
 {% highlight Dart %}


### PR DESCRIPTION
## Description

Updated the broken/invalid API documentation links in the following Markdown files. The links now point to their correct, live API documentation URLs and return HTTP 200.

### Files Updated
- `accessibility.md`
- `right-to-left.md`
- `pull-to-refresh.md`

---

## Broken Links — Before & After

### Screenshot
## Link Validation Summary

| Metric | Count |
|--------|-------|
| Markdown Files Scanned | 31 |
| URLs Found | 516 |
| HTTP 200 (OK) | 497 |
| Redirects | 9 |
| Broken Links | 10 |
| Server Errors | 0 |
| Validation Errors | 0 |
| Pending User Request | 9 |

> **Net effect of this PR:** Broken links reduced from 10 → 0 across the three updated files.

<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/6ca16df6-4e66-4c69-96cf-598c511421d4" />

After
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/eded7366-738e-46d8-86b2-c763d3130d55" />
 
