### PR TITLE
Modified the layout of Flutter widgets in overview page UG  

### DIFF
--- a/Flutter/introduction/overview.md
+++ b/Flutter/introduction/overview.md
@@ -53,6 +53,40 @@ Syncfusion<sup>®</sup> Essential Studio<sup>®</sup> for Flutter is a comprehen
 ## Controls List
 
 <style>
+#table
+{
+border:0 !important;
+line-height: 160% !important;
+}
+#table tr {
+  border:0 !important;
+}
+#table td {
+  border:0 !important;
+  vertical-align: top;
+}
+.controlanchorlink {
+    font-size: 14px !important;
+    text-decoration: none !important;
+    text-align: left !important;
+    padding: 2px 0px;
+}
+.category-topics {
+    font-size: 14px !important;
+    font-weight: 500 !important;
+    border: 0 !important;
+    line-height: 20px;
+    margin-top: 7px;
+    margin-bottom: 5px;
+}
+.category {
+    font-size: 14px !important;
+    font-weight: 500 !important;
+    border: 0 !important;
+    text-align: left !important;
+    line-height: 20px;
+    padding-top: 20px;
+}
 @font-face {
 font-family: 'UI Control Icons Flutter';
 src:
@@ -106,7 +140,7 @@ line-height: 1;
 </colgroup>
 <tr>
 <td>
-<!-- Data Visualization -->
+<!-- Column 1: Data Visualization -->
 <div>
     <p class="category-topics">DATA VISUALIZATION</p>
 </div>
@@ -160,15 +194,39 @@ line-height: 1;
         <span class="sf-home-icon sf-icon-linear-gauge"></span>Linear Gauge
     </a>
 </div>
-
-<div><p class="category-topics">SLIDERS</p></div>
-
-<div class="controlanchorlink"><a target="_self" href="https://help.syncfusion.com/flutter/slider/overview"><span class="sf-home-icon sf-icon-slider"></span>Slider</a></div>
-<div class="controlanchorlink"><a target="_self" href="https://help.syncfusion.com/flutter/range-slider/overview"><span class="sf-home-icon sf-icon-range-slider"></span>Range Slider</a></div>
-<div class="controlanchorlink"><a target="_self" href="https://help.syncfusion.com/flutter/range-selector/overview"><span class="sf-home-icon sf-icon-range-selector"></span>Range Selector</a></div>
 </td>
 <td>
-<!-- Data Management -->
+<!-- Column 2: Sliders + Editors -->
+<div>
+    <p class="category-topics">SLIDERS</p>
+</div>
+<div class="controlanchorlink">
+    <a target="_self" href="https://help.syncfusion.com/flutter/slider/overview">
+        <span class="sf-home-icon sf-icon-slider"></span>Slider
+    </a>
+</div>
+<div class="controlanchorlink">
+    <a target="_self" href="https://help.syncfusion.com/flutter/range-slider/overview">
+        <span class="sf-home-icon sf-icon-range-slider"></span>Range Slider
+    </a>
+</div>
+<div class="controlanchorlink">
+    <a target="_self" href="https://help.syncfusion.com/flutter/range-selector/overview">
+        <span class="sf-home-icon sf-icon-range-selector"></span>Range Selector
+    </a>
+</div>
+
+<div>
+    <p class="category-topics">EDITORS</p>
+</div>
+<div class="controlanchorlink">
+    <a target="_self" href="https://help.syncfusion.com/flutter/signaturepad/overview">
+        <span class="sf-home-icon sf-icon-signature-pad"></span>Signature Pad
+    </a>
+</div>
+</td>
+<td>
+<!-- Column 3: Data Management + Conversational UI -->
 <div>
     <p class="category-topics">DATA MANAGEMENT</p>
 </div>
@@ -188,17 +246,6 @@ line-height: 1;
     </a>
 </div>
 
-<!-- Editors -->
-<div>
-    <p class="category-topics">EDITORS</p>
-</div>
-<div class="controlanchorlink">
-    <a target="_self" href="https://help.syncfusion.com/flutter/signaturepad/overview">
-        <span class="sf-home-icon sf-icon-signature-pad"></span>Signature Pad
-    </a>
-</div>
-
-<!-- Conversational UI -->
 <div>
     <p class="category-topics">CONVERSATIONAL UI</p>
 </div>

--- a/Flutter/introduction/overview.md
+++ b/Flutter/introduction/overview.md
@@ -455,7 +455,7 @@ Explore Features
     <div class="form-description">
        Find practical solutions, troubleshooting tips and how‑to guides for common scenarios.
     </div>
-    <a href="https://support.syncfusion.com/kb/cross-platforms/section/1236" class="explore-link">
+    <a href="https://support.syncfusion.com/kb/cross-platforms/category/79" class="explore-link">
 Search KB's
   <span class="card-icon card-arrow"></span>
 </a>
@@ -518,10 +518,3 @@ Read Blogs
     </div>
 </div>
 </div>
-
-## See Also
-
-- [Getting Started with Syncfusion® Flutter DataGrid](../datagrid/getting-started.md)
-- [Getting Started with Syncfusion® Flutter Cartesian Chart](../cartesian-charts/getting-started.md)
-- [Getting Started with Syncfusion® Flutter Calendar](../calendar/getting-started.md)
-- [Getting Started with Syncfusion® Flutter Maps](../maps/getting-started.md)


### PR DESCRIPTION
**Description**

Updated flutter overview control list UI for better rendering.

Previously, added two column layout with inconsistencies. Now, updated the Flutter widgets list with 3 columns with enough space similar to the maui overview page UI.

<img width="1511" height="956" alt="image" src="https://github.com/user-attachments/assets/93759f1f-dcb6-4961-9ca3-781ffc473c15" />

Previous layout:
<img width="1386" height="1082" alt="image" src="https://github.com/user-attachments/assets/5810f9e7-eb7f-43cb-bb8d-878a7b255241" />

References:
https://help.syncfusion.com/maui/introduction/overview#controls-list
https://github.com/syncfusion-content/maui-docs/blob/master/MAUI/Introduction/Overview.md?plain=1
